### PR TITLE
fix: MIS-2092 Remove all date-time format for unsure formated data

### DIFF
--- a/api_files/postcast_api_openapi.json
+++ b/api_files/postcast_api_openapi.json
@@ -1493,7 +1493,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Actual Time of Arrival for the Final Vessel at the Port of Discharge (POD) - Local Time"
                     },
                     "pod_actual_arrival_lt_from_ais": {
@@ -1501,7 +1500,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Actual Time of Arrival for the Final Vessel at the Port of Discharge (POD) as per AIS Data- Local Time"
                     },
                     "pod_actual_departure_lt_from_ais": {
@@ -1509,7 +1507,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Actual Time of Departure for the Final Vessel from the Port of Discharge (POD) as per AIS Data - Local Time"
                     },
                     "pod_actual_discharge_lt": {
@@ -1517,7 +1514,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Actual Container Discharge Time from Final Vessel at the Port of Discharge (POD) - Local Time"
                     },
                     "pod_name": {
@@ -1530,7 +1526,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Portcast Predicted Time of Arrival for the Final Vessel at the Port of Discharge (POD) - Local Time [Most Reliable Source of ETA]"
                     },
                     "pod_predicted_departure_lt": {
@@ -1538,7 +1533,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Portcast Predicted Time of Departure for the Final Vessel from the Port of Discharge (POD) - Local Time"
                     },
                     "pod_scheduled_arrival_lt": {
@@ -1546,7 +1540,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Scheduled Time of Arrival for the Final Vessel at the Port of Discharge (POD) as per carrier T&T - Local Time"
                     },
                     "pod_scheduled_arrival_lt_first_seen": {
@@ -1564,7 +1557,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Scheduled Time of Arrival for the Final Vessel at the Port of Discharge (POD) as per vessel schedule - Local Time"
                     },
                     "pod_scheduled_departure_lt_from_schedule": {
@@ -1572,7 +1564,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Scheduled Time of Departure for the Final Vessel from the Port of Discharge (POD) as per vessel schedule - Local Time"
                     },
                     "pod_scheduled_discharge_lt": {
@@ -1580,7 +1571,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Carrier Scheduled Container Discharge Time from Final Vessel at the Port of Discharge (POD) - Local Time"
                     },
                     "pod_terminal_name": {
@@ -1599,7 +1589,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Actual Time of Arrival for the First Vessel at the Port of Loading (POL) as per AIS Data - Local Time"
                     },
                     "pol_actual_departure_lt": {
@@ -1607,7 +1596,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Actual Time of Departure for the First Vessel from the Port of Loading (POL) - Local Time"
                     },
                     "pol_actual_departure_lt_from_ais": {
@@ -1615,7 +1603,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Actual Time of Departure for the First Vessel from the Port of Loading (POL) as per AIS Data - Local Time"
                     },
                     "pol_actual_loading_lt": {
@@ -1623,7 +1610,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Actual Container Loading Time on First Vessel at the Port of Loading (POL) - Local Time"
                     },
                     "pol_name": {
@@ -1636,7 +1622,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Portcast Predicted Time of Arrival for the First Vessel at the Port of Loading (POL) - Local Time"
                     },
                     "pol_predicted_departure_lt": {
@@ -1644,7 +1629,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Portcast Predicted Time of Departure for the First Vessel from the Port of Loading (POL) - Local Time [Most Reliable Source of ETD]"
                     },
                     "pol_scheduled_arrival_lt_from_schedule": {
@@ -1652,7 +1636,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Scheduled Time of Arrival for the First Vessel at the Port of Loading (POL) as per Vessel Schedule - Local Time"
                     },
                     "pol_scheduled_departure_lt": {
@@ -1660,7 +1643,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Scheduled Time of Departure for the First Vessel from the Port of Loading (POL) as per Container T&T - Local Time"
                     },
                     "pol_scheduled_departure_lt_first_seen": {
@@ -1678,7 +1660,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Scheduled Time of Departure for the First Vessel from the Port of Loading (POL) as per Vessel Schedule - Local Time"
                     },
                     "pol_scheduled_loading_lt": {
@@ -1686,7 +1667,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Carrier Scheduled Container Loading Time on First Vessel at the Port of Loading (POL) - Local Time"
                     },
                     "pol_terminal_name": {
@@ -2296,32 +2276,28 @@
                                     "string",
                                     "null"
                                 ],
-                                "description": "Actual Arrival Time at the target port location - Local Time",
-                                "format": "date-time"
+                                "description": "Actual Arrival Time at the target port location - Local Time"
                             },
                             "pod_actual_arrival_lt_from_ais": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "Actual Arrival Time at the target port location as per AIS Data - Local Time",
-                                "format": "date-time"
+                                "description": "Actual Arrival Time at the target port location as per AIS Data - Local Time"
                             },
                             "pod_actual_departure_lt_from_ais": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "Actual Departure Time from the target port location as per AIS Data - Local Time",
-                                "format": "date-time"
+                                "description": "Actual Departure Time from the target port location as per AIS Data - Local Time"
                             },
                             "pod_actual_discharge_lt": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "Actual Time of Discharge at the target port location - Local Time",
-                                "format": "date-time"
+                                "description": "Actual Time of Discharge at the target port location - Local Time"
                             },
                             "pod_name": {
                                 "type": [
@@ -2336,48 +2312,42 @@
                                     "string",
                                     "null"
                                 ],
-                                "description": "Portcast Predicted Time of Arrival at the target port location - Local Time",
-                                "format": "date-time"
+                                "description": "Portcast Predicted Time of Arrival at the target port location - Local Time"
                             },
                             "pod_predicted_departure_lt": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "Portcast Predicted Time of Departure from the target port location - Local Time",
-                                "format": "date-time"
+                                "description": "Portcast Predicted Time of Departure from the target port location - Local Time"
                             },
                             "pod_scheduled_arrival_lt": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "Scheduled Time of Arrival at the target port location - Local Time",
-                                "format": "date-time"
+                                "description": "Scheduled Time of Arrival at the target port location - Local Time"
                             },
                             "pod_scheduled_arrival_lt_from_schedule": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "Scheduled Time of Arrival at the target port location as per Vessel Schedule - Local Time",
-                                "format": "date-time"
+                                "description": "Scheduled Time of Arrival at the target port location as per Vessel Schedule - Local Time"
                             },
                             "pod_scheduled_departure_lt_from_schedule": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "Scheduled Time of Departure from the target port location as per Vessel Schedule - Local Time",
-                                "format": "date-time"
+                                "description": "Scheduled Time of Departure from the target port location as per Vessel Schedule - Local Time"
                             },
                             "pod_scheduled_discharge_lt": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "Scheduled Discharge Time at the target port location - Local Time",
-                                "format": "date-time"
+                                "description": "Scheduled Discharge Time at the target port location - Local Time"
                             },
                             "pod_terminal_name": {
                                 "type": [
@@ -2400,32 +2370,28 @@
                                     "string",
                                     "null"
                                 ],
-                                "description": "Actual Time of Arrival at the starting port location as per AIS Data - Local Time",
-                                "format": "date-time"
+                                "description": "Actual Time of Arrival at the starting port location as per AIS Data - Local Time"
                             },
                             "pol_actual_departure_lt": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "Actual Time of Departure from the starting port location - Local Time",
-                                "format": "date-time"
+                                "description": "Actual Time of Departure from the starting port location - Local Time"
                             },
                             "pol_actual_departure_lt_from_ais": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "Actual Time of Departure from the starting port location as per AIS Data - Local Time",
-                                "format": "date-time"
+                                "description": "Actual Time of Departure from the starting port location as per AIS Data - Local Time"
                             },
                             "pol_actual_loading_lt": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "Actual Loading Time at the starting port location - Local Time",
-                                "format": "date-time"
+                                "description": "Actual Loading Time at the starting port location - Local Time"
                             },
                             "pol_name": {
                                 "type": [
@@ -2440,48 +2406,42 @@
                                     "string",
                                     "null"
                                 ],
-                                "description": "Portcast Predicted Time of Arrival at the starting port location - Local Time",
-                                "format": "date-time"
+                                "description": "Portcast Predicted Time of Arrival at the starting port location - Local Time"
                             },
                             "pol_predicted_departure_lt": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "Portcast Predicted Time of Departure from the starting port location - Local Time",
-                                "format": "date-time"
+                                "description": "Portcast Predicted Time of Departure from the starting port location - Local Time"
                             },
                             "pol_scheduled_arrival_lt_from_schedule": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "Scheduled Time of Arrival at the starting port location as per Vessel Schedule- Local Time",
-                                "format": "date-time"
+                                "description": "Scheduled Time of Arrival at the starting port location as per Vessel Schedule- Local Time"
                             },
                             "pol_scheduled_departure_lt": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "Scheduled Time of Departure from the starting port location - Local Time",
-                                "format": "date-time"
+                                "description": "Scheduled Time of Departure from the starting port location - Local Time"
                             },
                             "pol_scheduled_departure_lt_from_schedule": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "Scheduled Time of Departure from the starting port location as per Vessel Schedule - Local Time",
-                                "format": "date-time"
+                                "description": "Scheduled Time of Departure from the starting port location as per Vessel Schedule - Local Time"
                             },
                             "pol_scheduled_loading_lt": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "Scheduled Loading Time at the starting port location - Local Time",
-                                "format": "date-time"
+                                "description": "Scheduled Loading Time at the starting port location - Local Time"
                             },
                             "pol_terminal_name": {
                                 "type": [
@@ -2656,7 +2616,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Actual Time of Arrival - Local Time"
                     },
                     "actual_arrival_utc": {
@@ -2672,7 +2631,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Actual Time of Departure - Local Time"
                     },
                     "actual_departure_utc": {
@@ -2727,7 +2685,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Portcast Predicted Arrival Time - Local Time"
                     },
                     "predicted_arrival_utc": {
@@ -2743,7 +2700,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Portcast Predicted Departure Time - Local Time"
                     },
                     "predicted_departure_utc": {
@@ -2767,7 +2723,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Vessel Scheduled Arrival Time - Local Time"
                     },
                     "scheduled_arrival_utc": {
@@ -2783,7 +2738,6 @@
                             "string",
                             "null"
                         ],
-                        "format": "date-time",
                         "description": "Vessel Scheduled Departure Time - Local Time"
                     },
                     "scheduled_departure_utc": {
@@ -3354,13 +3308,11 @@
                             "erd_standard": {
                                 "type": "string",
                                 "description": "Earliest Receipt Date (ERD) for a standard container, as reported by the terminal - Local Time.",
-                                "format": "date-time",
                                 "example": "2023-06-24T14:15:22Z"
                             },
                             "erd_reefer": {
                                 "type": "string",
                                 "description": "Earliest Receipt Date (ERD) for a reefer container, as reported by the terminal - Local Time.",
-                                "format": "date-time",
                                 "example": "2023-06-24T14:15:22Z"
                             },
                             "gate_in_date": {
@@ -3371,37 +3323,31 @@
                             "port_cutoff_standard": {
                                 "type": "string",
                                 "description": "Last possible date and time for gating-in standard container at the export terminal, as reported by the Terminal - Local Time.",
-                                "format": "date-time",
                                 "example": "2023-06-23T14:15:22Z"
                             },
                             "port_cutoff_reefer": {
                                 "type": "string",
                                 "description": "Last possible date and time for gating-in reefer container at the export terminal, as reported by the terminal - Local Time.",
-                                "format": "date-time",
                                 "example": "2023-06-23T14:15:22Z"
                             },
                             "latest_eta": {
                                 "type": "string",
                                 "description": "Latest vessel ETA to the export port, as reported by the terminal - Local Time.",
-                                "format": "date-time",
                                 "example": "2023-06-24T14:15:22Z"
                             },
                             "actual_arrival": {
                                 "type": "string",
                                 "description": "Actual vessel time of arrival, as reported by the terminal - Local Time.",
-                                "format": "date-time",
                                 "example": "2023-06-24T14:15:22Z"
                             },
                             "latest_etd": {
                                 "type": "string",
                                 "description": "Latest vessel ETD from the export port, as reported by the terminal - Local Time.",
-                                "format": "date-time",
                                 "example": "2023-06-26T14:15:22Z"
                             },
                             "actual_departure": {
                                 "type": "string",
                                 "description": "Actual vessel time of departure from the export port, as reported by the terminal - Local Time.",
-                                "format": "date-time",
                                 "pattern": "2023-06-26T14:15:22Z"
                             }
                         }

--- a/portcast/api/openapi.yaml
+++ b/portcast/api/openapi.yaml
@@ -957,40 +957,40 @@ components:
           sailing_info:
             vessel_flag: SG
             voyage_no: CG303R
-            pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
             pod: ESBCN
-            pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-            pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
+            pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
             imo: "9306172"
-            pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pol_actual_departure_lt: pol_actual_departure_lt
             pol: USHOU
-            pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-            pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-            pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_departure_lt: pol_scheduled_departure_lt
+            pod_actual_arrival_lt: pod_actual_arrival_lt
+            pod_actual_discharge_lt: pod_actual_discharge_lt
+            pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
             pod_terminal_name: BARCELONA EUROPE SOUTH TERMINAL
             id: 94e3dc60-2039-4a54-a88c-7c5885fd7988
-            pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+            pol_predicted_arrival_lt: pol_predicted_arrival_lt
+            pod_predicted_arrival_lt: pod_predicted_arrival_lt
             vessel_leg: 1
             is_active: true
-            pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+            pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
             created: 2000-01-23T04:56:07.000+00:00
             vessel_name: MAERSK PUELO
             pol_name: HOUSTON
             pod_name: BARCELONA
-            pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pod_predicted_departure_lt: pod_predicted_departure_lt
             pol_terminal_name: BAYPORT TERMINAL
-            pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_loading_lt: pol_scheduled_loading_lt
             carrier_no: CMDU
-            pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-            pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-            pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+            pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+            pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
             updated: 2000-01-23T04:56:07.000+00:00
-            pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-            pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-            pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+            pol_actual_loading_lt: pol_actual_loading_lt
+            pol_predicted_departure_lt: pol_predicted_departure_lt
           status_info:
             vessel:
               metadata:
@@ -1013,19 +1013,19 @@ components:
           voyage_details:
           - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
             timezone: UTC +2
-            predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            predicted_departure_lt: predicted_departure_lt
             index: 1
             lon: 15.901825
-            predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+            predicted_arrival_lt: predicted_arrival_lt
+            scheduled_arrival_lt: scheduled_arrival_lt
+            actual_departure_lt: actual_departure_lt
             port_name: GIOIA TAURO
             scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
             prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-            actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+            actual_arrival_lt: actual_arrival_lt
             predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
             scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-            scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+            scheduled_departure_lt: scheduled_departure_lt
             actual_departure_utc: 2000-01-23T04:56:07.000+00:00
             voyage_no_list:
             - CG303R
@@ -1040,19 +1040,19 @@ components:
             port_code: ITGIT
           - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
             timezone: UTC +2
-            predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            predicted_departure_lt: predicted_departure_lt
             index: 1
             lon: 15.901825
-            predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+            predicted_arrival_lt: predicted_arrival_lt
+            scheduled_arrival_lt: scheduled_arrival_lt
+            actual_departure_lt: actual_departure_lt
             port_name: GIOIA TAURO
             scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
             prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-            actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+            actual_arrival_lt: actual_arrival_lt
             predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
             scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-            scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+            scheduled_departure_lt: scheduled_departure_lt
             actual_departure_utc: 2000-01-23T04:56:07.000+00:00
             voyage_no_list:
             - CG303R
@@ -1070,40 +1070,40 @@ components:
           sailing_info:
             vessel_flag: SG
             voyage_no: CG303R
-            pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
             pod: ESBCN
-            pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-            pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
+            pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
             imo: "9306172"
-            pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pol_actual_departure_lt: pol_actual_departure_lt
             pol: USHOU
-            pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-            pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-            pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_departure_lt: pol_scheduled_departure_lt
+            pod_actual_arrival_lt: pod_actual_arrival_lt
+            pod_actual_discharge_lt: pod_actual_discharge_lt
+            pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
             pod_terminal_name: BARCELONA EUROPE SOUTH TERMINAL
             id: 94e3dc60-2039-4a54-a88c-7c5885fd7988
-            pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+            pol_predicted_arrival_lt: pol_predicted_arrival_lt
+            pod_predicted_arrival_lt: pod_predicted_arrival_lt
             vessel_leg: 1
             is_active: true
-            pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+            pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
             created: 2000-01-23T04:56:07.000+00:00
             vessel_name: MAERSK PUELO
             pol_name: HOUSTON
             pod_name: BARCELONA
-            pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pod_predicted_departure_lt: pod_predicted_departure_lt
             pol_terminal_name: BAYPORT TERMINAL
-            pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_loading_lt: pol_scheduled_loading_lt
             carrier_no: CMDU
-            pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-            pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-            pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+            pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+            pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
             updated: 2000-01-23T04:56:07.000+00:00
-            pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-            pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-            pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+            pol_actual_loading_lt: pol_actual_loading_lt
+            pol_predicted_departure_lt: pol_predicted_departure_lt
           status_info:
             vessel:
               metadata:
@@ -1126,19 +1126,19 @@ components:
           voyage_details:
           - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
             timezone: UTC +2
-            predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            predicted_departure_lt: predicted_departure_lt
             index: 1
             lon: 15.901825
-            predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+            predicted_arrival_lt: predicted_arrival_lt
+            scheduled_arrival_lt: scheduled_arrival_lt
+            actual_departure_lt: actual_departure_lt
             port_name: GIOIA TAURO
             scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
             prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-            actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+            actual_arrival_lt: actual_arrival_lt
             predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
             scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-            scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+            scheduled_departure_lt: scheduled_departure_lt
             actual_departure_utc: 2000-01-23T04:56:07.000+00:00
             voyage_no_list:
             - CG303R
@@ -1153,19 +1153,19 @@ components:
             port_code: ITGIT
           - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
             timezone: UTC +2
-            predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            predicted_departure_lt: predicted_departure_lt
             index: 1
             lon: 15.901825
-            predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+            predicted_arrival_lt: predicted_arrival_lt
+            scheduled_arrival_lt: scheduled_arrival_lt
+            actual_departure_lt: actual_departure_lt
             port_name: GIOIA TAURO
             scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
             prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-            actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+            actual_arrival_lt: actual_arrival_lt
             predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
             scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-            scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+            scheduled_departure_lt: scheduled_departure_lt
             actual_departure_utc: 2000-01-23T04:56:07.000+00:00
             voyage_no_list:
             - CG303R
@@ -1195,42 +1195,42 @@ components:
         bill_of_lading:
           bl_no: COSU6349613240
           cntr_no: BMOU1589176
-          pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+          pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
           pod: GHTEM
-          pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+          pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
           place_of_delivery_name: NORFOLK
           place_of_receipt_name: TEMA
-          pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
-          pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+          pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
+          pol_actual_departure_lt: pol_actual_departure_lt
           pol: USORF
-          pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-          pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-          pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-          pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+          pol_scheduled_departure_lt: pol_scheduled_departure_lt
+          pod_actual_arrival_lt: pod_actual_arrival_lt
+          pod_actual_discharge_lt: pod_actual_discharge_lt
+          pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
           pod_terminal_name: MERIDIAN PORT SERVICE LIMITED
           id: 16caa040-f582-4c15-88c9-2e80437e7916
-          pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-          pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+          pol_predicted_arrival_lt: pol_predicted_arrival_lt
+          pod_predicted_arrival_lt: pod_predicted_arrival_lt
           pol_scheduled_departure_lt_first_seen: pol_scheduled_departure_lt_first_seen
           place_of_delivery: USORF
-          pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-          pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+          pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+          pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
           created: 2000-01-23T04:56:07.000+00:00
           pol_name: NORFOLK
           pod_scheduled_arrival_lt_first_seen: pod_scheduled_arrival_lt_first_seen
           pod_name: TEMA
           place_of_receipt: GHTEM
-          pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+          pod_predicted_departure_lt: pod_predicted_departure_lt
           pol_terminal_name: PPCY EMPTY DEPOT
-          pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+          pol_scheduled_loading_lt: pol_scheduled_loading_lt
           carrier_no: COSU
-          pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-          pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-          pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+          pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+          pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+          pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
           updated: 2000-01-23T04:56:07.000+00:00
-          pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-          pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-          pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+          pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+          pol_actual_loading_lt: pol_actual_loading_lt
+          pol_predicted_departure_lt: pol_predicted_departure_lt
         delay_lists:
         - port_name: XIAMEN
           reason_code: RLV
@@ -1341,42 +1341,42 @@ components:
       example:
         bl_no: COSU6349613240
         cntr_no: BMOU1589176
-        pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+        pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
         pod: GHTEM
-        pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+        pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
         place_of_delivery_name: NORFOLK
         place_of_receipt_name: TEMA
-        pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
-        pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+        pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
+        pol_actual_departure_lt: pol_actual_departure_lt
         pol: USORF
-        pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-        pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-        pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-        pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+        pol_scheduled_departure_lt: pol_scheduled_departure_lt
+        pod_actual_arrival_lt: pod_actual_arrival_lt
+        pod_actual_discharge_lt: pod_actual_discharge_lt
+        pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
         pod_terminal_name: MERIDIAN PORT SERVICE LIMITED
         id: 16caa040-f582-4c15-88c9-2e80437e7916
-        pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-        pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+        pol_predicted_arrival_lt: pol_predicted_arrival_lt
+        pod_predicted_arrival_lt: pod_predicted_arrival_lt
         pol_scheduled_departure_lt_first_seen: pol_scheduled_departure_lt_first_seen
         place_of_delivery: USORF
-        pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-        pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+        pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+        pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
         created: 2000-01-23T04:56:07.000+00:00
         pol_name: NORFOLK
         pod_scheduled_arrival_lt_first_seen: pod_scheduled_arrival_lt_first_seen
         pod_name: TEMA
         place_of_receipt: GHTEM
-        pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+        pod_predicted_departure_lt: pod_predicted_departure_lt
         pol_terminal_name: PPCY EMPTY DEPOT
-        pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+        pol_scheduled_loading_lt: pol_scheduled_loading_lt
         carrier_no: COSU
-        pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-        pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-        pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+        pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+        pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+        pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
         updated: 2000-01-23T04:56:07.000+00:00
-        pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-        pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-        pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+        pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+        pol_actual_loading_lt: pol_actual_loading_lt
+        pol_predicted_departure_lt: pol_predicted_departure_lt
       properties:
         bl_no:
           description: Bill of Lading or Booking Number
@@ -1428,25 +1428,21 @@ components:
         pod_actual_arrival_lt:
           description: Actual Time of Arrival for the Final Vessel at the Port of
             Discharge (POD) - Local Time
-          format: date-time
           nullable: true
           type: string
         pod_actual_arrival_lt_from_ais:
           description: Actual Time of Arrival for the Final Vessel at the Port of
             Discharge (POD) as per AIS Data- Local Time
-          format: date-time
           nullable: true
           type: string
         pod_actual_departure_lt_from_ais:
           description: Actual Time of Departure for the Final Vessel from the Port
             of Discharge (POD) as per AIS Data - Local Time
-          format: date-time
           nullable: true
           type: string
         pod_actual_discharge_lt:
           description: Actual Container Discharge Time from Final Vessel at the Port
             of Discharge (POD) - Local Time
-          format: date-time
           nullable: true
           type: string
         pod_name:
@@ -1456,19 +1452,16 @@ components:
         pod_predicted_arrival_lt:
           description: "Portcast Predicted Time of Arrival for the Final Vessel at\
             \ the Port of Discharge (POD) - Local Time [Most Reliable Source of ETA]"
-          format: date-time
           nullable: true
           type: string
         pod_predicted_departure_lt:
           description: Portcast Predicted Time of Departure for the Final Vessel from
             the Port of Discharge (POD) - Local Time
-          format: date-time
           nullable: true
           type: string
         pod_scheduled_arrival_lt:
           description: Scheduled Time of Arrival for the Final Vessel at the Port
             of Discharge (POD) as per carrier T&T - Local Time
-          format: date-time
           nullable: true
           type: string
         pod_scheduled_arrival_lt_first_seen:
@@ -1481,19 +1474,16 @@ components:
         pod_scheduled_arrival_lt_from_schedule:
           description: Scheduled Time of Arrival for the Final Vessel at the Port
             of Discharge (POD) as per vessel schedule - Local Time
-          format: date-time
           nullable: true
           type: string
         pod_scheduled_departure_lt_from_schedule:
           description: Scheduled Time of Departure for the Final Vessel from the Port
             of Discharge (POD) as per vessel schedule - Local Time
-          format: date-time
           nullable: true
           type: string
         pod_scheduled_discharge_lt:
           description: Carrier Scheduled Container Discharge Time from Final Vessel
             at the Port of Discharge (POD) - Local Time
-          format: date-time
           nullable: true
           type: string
         pod_terminal_name:
@@ -1508,25 +1498,21 @@ components:
         pol_actual_arrival_lt_from_ais:
           description: Actual Time of Arrival for the First Vessel at the Port of
             Loading (POL) as per AIS Data - Local Time
-          format: date-time
           nullable: true
           type: string
         pol_actual_departure_lt:
           description: Actual Time of Departure for the First Vessel from the Port
             of Loading (POL) - Local Time
-          format: date-time
           nullable: true
           type: string
         pol_actual_departure_lt_from_ais:
           description: Actual Time of Departure for the First Vessel from the Port
             of Loading (POL) as per AIS Data - Local Time
-          format: date-time
           nullable: true
           type: string
         pol_actual_loading_lt:
           description: Actual Container Loading Time on First Vessel at the Port of
             Loading (POL) - Local Time
-          format: date-time
           nullable: true
           type: string
         pol_name:
@@ -1536,26 +1522,22 @@ components:
         pol_predicted_arrival_lt:
           description: Portcast Predicted Time of Arrival for the First Vessel at
             the Port of Loading (POL) - Local Time
-          format: date-time
           nullable: true
           type: string
         pol_predicted_departure_lt:
           description: "Portcast Predicted Time of Departure for the First Vessel\
             \ from the Port of Loading (POL) - Local Time [Most Reliable Source of\
             \ ETD]"
-          format: date-time
           nullable: true
           type: string
         pol_scheduled_arrival_lt_from_schedule:
           description: Scheduled Time of Arrival for the First Vessel at the Port
             of Loading (POL) as per Vessel Schedule - Local Time
-          format: date-time
           nullable: true
           type: string
         pol_scheduled_departure_lt:
           description: Scheduled Time of Departure for the First Vessel from the Port
             of Loading (POL) as per Container T&T - Local Time
-          format: date-time
           nullable: true
           type: string
         pol_scheduled_departure_lt_first_seen:
@@ -1568,13 +1550,11 @@ components:
         pol_scheduled_departure_lt_from_schedule:
           description: Scheduled Time of Departure for the First Vessel from the Port
             of Loading (POL) as per Vessel Schedule - Local Time
-          format: date-time
           nullable: true
           type: string
         pol_scheduled_loading_lt:
           description: Carrier Scheduled Container Loading Time on First Vessel at
             the Port of Loading (POL) - Local Time
-          format: date-time
           nullable: true
           type: string
         pol_terminal_name:
@@ -1935,40 +1915,40 @@ components:
         sailing_info:
           vessel_flag: SG
           voyage_no: CG303R
-          pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+          pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
           pod: ESBCN
-          pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-          pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
+          pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
+          pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
           imo: "9306172"
-          pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+          pol_actual_departure_lt: pol_actual_departure_lt
           pol: USHOU
-          pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-          pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-          pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-          pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+          pol_scheduled_departure_lt: pol_scheduled_departure_lt
+          pod_actual_arrival_lt: pod_actual_arrival_lt
+          pod_actual_discharge_lt: pod_actual_discharge_lt
+          pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
           pod_terminal_name: BARCELONA EUROPE SOUTH TERMINAL
           id: 94e3dc60-2039-4a54-a88c-7c5885fd7988
-          pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-          pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+          pol_predicted_arrival_lt: pol_predicted_arrival_lt
+          pod_predicted_arrival_lt: pod_predicted_arrival_lt
           vessel_leg: 1
           is_active: true
-          pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-          pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+          pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+          pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
           created: 2000-01-23T04:56:07.000+00:00
           vessel_name: MAERSK PUELO
           pol_name: HOUSTON
           pod_name: BARCELONA
-          pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+          pod_predicted_departure_lt: pod_predicted_departure_lt
           pol_terminal_name: BAYPORT TERMINAL
-          pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+          pol_scheduled_loading_lt: pol_scheduled_loading_lt
           carrier_no: CMDU
-          pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-          pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-          pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+          pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+          pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+          pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
           updated: 2000-01-23T04:56:07.000+00:00
-          pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-          pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-          pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+          pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+          pol_actual_loading_lt: pol_actual_loading_lt
+          pol_predicted_departure_lt: pol_predicted_departure_lt
         status_info:
           vessel:
             metadata:
@@ -1991,19 +1971,19 @@ components:
         voyage_details:
         - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
           timezone: UTC +2
-          predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+          predicted_departure_lt: predicted_departure_lt
           index: 1
           lon: 15.901825
-          predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-          scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-          actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+          predicted_arrival_lt: predicted_arrival_lt
+          scheduled_arrival_lt: scheduled_arrival_lt
+          actual_departure_lt: actual_departure_lt
           port_name: GIOIA TAURO
           scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
           prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-          actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+          actual_arrival_lt: actual_arrival_lt
           predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
           scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-          scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+          scheduled_departure_lt: scheduled_departure_lt
           actual_departure_utc: 2000-01-23T04:56:07.000+00:00
           voyage_no_list:
           - CG303R
@@ -2018,19 +1998,19 @@ components:
           port_code: ITGIT
         - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
           timezone: UTC +2
-          predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+          predicted_departure_lt: predicted_departure_lt
           index: 1
           lon: 15.901825
-          predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-          scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-          actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+          predicted_arrival_lt: predicted_arrival_lt
+          scheduled_arrival_lt: scheduled_arrival_lt
+          actual_departure_lt: actual_departure_lt
           port_name: GIOIA TAURO
           scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
           prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-          actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+          actual_arrival_lt: actual_arrival_lt
           predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
           scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-          scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+          scheduled_departure_lt: scheduled_departure_lt
           actual_departure_utc: 2000-01-23T04:56:07.000+00:00
           voyage_no_list:
           - CG303R
@@ -2072,19 +2052,19 @@ components:
       example:
         actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
         timezone: UTC +2
-        predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+        predicted_departure_lt: predicted_departure_lt
         index: 1
         lon: 15.901825
-        predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-        scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-        actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+        predicted_arrival_lt: predicted_arrival_lt
+        scheduled_arrival_lt: scheduled_arrival_lt
+        actual_departure_lt: actual_departure_lt
         port_name: GIOIA TAURO
         scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
         prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-        actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+        actual_arrival_lt: actual_arrival_lt
         predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
         scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-        scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+        scheduled_departure_lt: scheduled_departure_lt
         actual_departure_utc: 2000-01-23T04:56:07.000+00:00
         voyage_no_list:
         - CG303R
@@ -2105,7 +2085,6 @@ components:
           type: string
         actual_arrival_lt:
           description: Actual Time of Arrival - Local Time
-          format: date-time
           nullable: true
           type: string
         actual_arrival_utc:
@@ -2115,7 +2094,6 @@ components:
           type: string
         actual_departure_lt:
           description: Actual Time of Departure - Local Time
-          format: date-time
           nullable: true
           type: string
         actual_departure_utc:
@@ -2156,7 +2134,6 @@ components:
           type: string
         predicted_arrival_lt:
           description: Portcast Predicted Arrival Time - Local Time
-          format: date-time
           nullable: true
           type: string
         predicted_arrival_utc:
@@ -2166,7 +2143,6 @@ components:
           type: string
         predicted_departure_lt:
           description: Portcast Predicted Departure Time - Local Time
-          format: date-time
           nullable: true
           type: string
         predicted_departure_utc:
@@ -2181,7 +2157,6 @@ components:
           type: string
         scheduled_arrival_lt:
           description: Vessel Scheduled Arrival Time - Local Time
-          format: date-time
           nullable: true
           type: string
         scheduled_arrival_utc:
@@ -2191,7 +2166,6 @@ components:
           type: string
         scheduled_departure_lt:
           description: Vessel Scheduled Departure Time - Local Time
-          format: date-time
           nullable: true
           type: string
         scheduled_departure_utc:
@@ -2370,7 +2344,7 @@ components:
           gate_in_date: 2023-06-21T14:15:22Z
           port_cutoff_standard: 2023-06-23T14:15:22Z
           erd_reefer: 2023-06-24T14:15:22Z
-          actual_departure: 2000-01-23T04:56:07.000+00:00
+          actual_departure: actual_departure
           id: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
           updated: 2000-01-23T04:56:07.000+00:00
           port_code: SGSIN
@@ -2645,40 +2619,40 @@ components:
             sailing_info:
               vessel_flag: SG
               voyage_no: CG303R
-              pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
               pod: ESBCN
-              pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
+              pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
               imo: "9306172"
-              pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_departure_lt: pol_actual_departure_lt
               pol: USHOU
-              pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-              pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt: pol_scheduled_departure_lt
+              pod_actual_arrival_lt: pod_actual_arrival_lt
+              pod_actual_discharge_lt: pod_actual_discharge_lt
+              pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
               pod_terminal_name: BARCELONA EUROPE SOUTH TERMINAL
               id: 94e3dc60-2039-4a54-a88c-7c5885fd7988
-              pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              pol_predicted_arrival_lt: pol_predicted_arrival_lt
+              pod_predicted_arrival_lt: pod_predicted_arrival_lt
               vessel_leg: 1
               is_active: true
-              pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+              pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
               created: 2000-01-23T04:56:07.000+00:00
               vessel_name: MAERSK PUELO
               pol_name: HOUSTON
               pod_name: BARCELONA
-              pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pod_predicted_departure_lt: pod_predicted_departure_lt
               pol_terminal_name: BAYPORT TERMINAL
-              pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_loading_lt: pol_scheduled_loading_lt
               carrier_no: CMDU
-              pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+              pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+              pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
               updated: 2000-01-23T04:56:07.000+00:00
-              pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-              pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+              pol_actual_loading_lt: pol_actual_loading_lt
+              pol_predicted_departure_lt: pol_predicted_departure_lt
             status_info:
               vessel:
                 metadata:
@@ -2701,19 +2675,19 @@ components:
             voyage_details:
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -2728,19 +2702,19 @@ components:
               port_code: ITGIT
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -2758,40 +2732,40 @@ components:
             sailing_info:
               vessel_flag: SG
               voyage_no: CG303R
-              pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
               pod: ESBCN
-              pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
+              pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
               imo: "9306172"
-              pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_departure_lt: pol_actual_departure_lt
               pol: USHOU
-              pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-              pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt: pol_scheduled_departure_lt
+              pod_actual_arrival_lt: pod_actual_arrival_lt
+              pod_actual_discharge_lt: pod_actual_discharge_lt
+              pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
               pod_terminal_name: BARCELONA EUROPE SOUTH TERMINAL
               id: 94e3dc60-2039-4a54-a88c-7c5885fd7988
-              pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              pol_predicted_arrival_lt: pol_predicted_arrival_lt
+              pod_predicted_arrival_lt: pod_predicted_arrival_lt
               vessel_leg: 1
               is_active: true
-              pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+              pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
               created: 2000-01-23T04:56:07.000+00:00
               vessel_name: MAERSK PUELO
               pol_name: HOUSTON
               pod_name: BARCELONA
-              pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pod_predicted_departure_lt: pod_predicted_departure_lt
               pol_terminal_name: BAYPORT TERMINAL
-              pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_loading_lt: pol_scheduled_loading_lt
               carrier_no: CMDU
-              pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+              pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+              pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
               updated: 2000-01-23T04:56:07.000+00:00
-              pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-              pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+              pol_actual_loading_lt: pol_actual_loading_lt
+              pol_predicted_departure_lt: pol_predicted_departure_lt
             status_info:
               vessel:
                 metadata:
@@ -2814,19 +2788,19 @@ components:
             voyage_details:
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -2841,19 +2815,19 @@ components:
               port_code: ITGIT
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -2883,42 +2857,42 @@ components:
           bill_of_lading:
             bl_no: COSU6349613240
             cntr_no: BMOU1589176
-            pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
             pod: GHTEM
-            pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
             place_of_delivery_name: NORFOLK
             place_of_receipt_name: TEMA
-            pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
-            pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
+            pol_actual_departure_lt: pol_actual_departure_lt
             pol: USORF
-            pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-            pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-            pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_departure_lt: pol_scheduled_departure_lt
+            pod_actual_arrival_lt: pod_actual_arrival_lt
+            pod_actual_discharge_lt: pod_actual_discharge_lt
+            pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
             pod_terminal_name: MERIDIAN PORT SERVICE LIMITED
             id: 16caa040-f582-4c15-88c9-2e80437e7916
-            pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+            pol_predicted_arrival_lt: pol_predicted_arrival_lt
+            pod_predicted_arrival_lt: pod_predicted_arrival_lt
             pol_scheduled_departure_lt_first_seen: pol_scheduled_departure_lt_first_seen
             place_of_delivery: USORF
-            pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+            pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
             created: 2000-01-23T04:56:07.000+00:00
             pol_name: NORFOLK
             pod_scheduled_arrival_lt_first_seen: pod_scheduled_arrival_lt_first_seen
             pod_name: TEMA
             place_of_receipt: GHTEM
-            pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pod_predicted_departure_lt: pod_predicted_departure_lt
             pol_terminal_name: PPCY EMPTY DEPOT
-            pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_loading_lt: pol_scheduled_loading_lt
             carrier_no: COSU
-            pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-            pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-            pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+            pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+            pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
             updated: 2000-01-23T04:56:07.000+00:00
-            pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-            pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-            pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+            pol_actual_loading_lt: pol_actual_loading_lt
+            pol_predicted_departure_lt: pol_predicted_departure_lt
           delay_lists:
           - port_name: XIAMEN
             reason_code: RLV
@@ -3038,40 +3012,40 @@ components:
             sailing_info:
               vessel_flag: SG
               voyage_no: CG303R
-              pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
               pod: ESBCN
-              pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
+              pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
               imo: "9306172"
-              pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_departure_lt: pol_actual_departure_lt
               pol: USHOU
-              pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-              pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt: pol_scheduled_departure_lt
+              pod_actual_arrival_lt: pod_actual_arrival_lt
+              pod_actual_discharge_lt: pod_actual_discharge_lt
+              pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
               pod_terminal_name: BARCELONA EUROPE SOUTH TERMINAL
               id: 94e3dc60-2039-4a54-a88c-7c5885fd7988
-              pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              pol_predicted_arrival_lt: pol_predicted_arrival_lt
+              pod_predicted_arrival_lt: pod_predicted_arrival_lt
               vessel_leg: 1
               is_active: true
-              pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+              pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
               created: 2000-01-23T04:56:07.000+00:00
               vessel_name: MAERSK PUELO
               pol_name: HOUSTON
               pod_name: BARCELONA
-              pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pod_predicted_departure_lt: pod_predicted_departure_lt
               pol_terminal_name: BAYPORT TERMINAL
-              pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_loading_lt: pol_scheduled_loading_lt
               carrier_no: CMDU
-              pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+              pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+              pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
               updated: 2000-01-23T04:56:07.000+00:00
-              pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-              pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+              pol_actual_loading_lt: pol_actual_loading_lt
+              pol_predicted_departure_lt: pol_predicted_departure_lt
             status_info:
               vessel:
                 metadata:
@@ -3094,19 +3068,19 @@ components:
             voyage_details:
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -3121,19 +3095,19 @@ components:
               port_code: ITGIT
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -3151,40 +3125,40 @@ components:
             sailing_info:
               vessel_flag: SG
               voyage_no: CG303R
-              pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
               pod: ESBCN
-              pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
+              pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
               imo: "9306172"
-              pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_departure_lt: pol_actual_departure_lt
               pol: USHOU
-              pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-              pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt: pol_scheduled_departure_lt
+              pod_actual_arrival_lt: pod_actual_arrival_lt
+              pod_actual_discharge_lt: pod_actual_discharge_lt
+              pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
               pod_terminal_name: BARCELONA EUROPE SOUTH TERMINAL
               id: 94e3dc60-2039-4a54-a88c-7c5885fd7988
-              pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              pol_predicted_arrival_lt: pol_predicted_arrival_lt
+              pod_predicted_arrival_lt: pod_predicted_arrival_lt
               vessel_leg: 1
               is_active: true
-              pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+              pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
               created: 2000-01-23T04:56:07.000+00:00
               vessel_name: MAERSK PUELO
               pol_name: HOUSTON
               pod_name: BARCELONA
-              pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pod_predicted_departure_lt: pod_predicted_departure_lt
               pol_terminal_name: BAYPORT TERMINAL
-              pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_loading_lt: pol_scheduled_loading_lt
               carrier_no: CMDU
-              pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+              pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+              pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
               updated: 2000-01-23T04:56:07.000+00:00
-              pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-              pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+              pol_actual_loading_lt: pol_actual_loading_lt
+              pol_predicted_departure_lt: pol_predicted_departure_lt
             status_info:
               vessel:
                 metadata:
@@ -3207,19 +3181,19 @@ components:
             voyage_details:
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -3234,19 +3208,19 @@ components:
               port_code: ITGIT
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -3276,42 +3250,42 @@ components:
           bill_of_lading:
             bl_no: COSU6349613240
             cntr_no: BMOU1589176
-            pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
             pod: GHTEM
-            pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
             place_of_delivery_name: NORFOLK
             place_of_receipt_name: TEMA
-            pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
-            pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
+            pol_actual_departure_lt: pol_actual_departure_lt
             pol: USORF
-            pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-            pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-            pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_departure_lt: pol_scheduled_departure_lt
+            pod_actual_arrival_lt: pod_actual_arrival_lt
+            pod_actual_discharge_lt: pod_actual_discharge_lt
+            pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
             pod_terminal_name: MERIDIAN PORT SERVICE LIMITED
             id: 16caa040-f582-4c15-88c9-2e80437e7916
-            pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+            pol_predicted_arrival_lt: pol_predicted_arrival_lt
+            pod_predicted_arrival_lt: pod_predicted_arrival_lt
             pol_scheduled_departure_lt_first_seen: pol_scheduled_departure_lt_first_seen
             place_of_delivery: USORF
-            pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+            pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
             created: 2000-01-23T04:56:07.000+00:00
             pol_name: NORFOLK
             pod_scheduled_arrival_lt_first_seen: pod_scheduled_arrival_lt_first_seen
             pod_name: TEMA
             place_of_receipt: GHTEM
-            pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pod_predicted_departure_lt: pod_predicted_departure_lt
             pol_terminal_name: PPCY EMPTY DEPOT
-            pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_loading_lt: pol_scheduled_loading_lt
             carrier_no: COSU
-            pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-            pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-            pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+            pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+            pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
             updated: 2000-01-23T04:56:07.000+00:00
-            pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-            pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-            pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+            pol_actual_loading_lt: pol_actual_loading_lt
+            pol_predicted_departure_lt: pol_predicted_departure_lt
           delay_lists:
           - port_name: XIAMEN
             reason_code: RLV
@@ -3431,40 +3405,40 @@ components:
             sailing_info:
               vessel_flag: SG
               voyage_no: CG303R
-              pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
               pod: ESBCN
-              pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
+              pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
               imo: "9306172"
-              pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_departure_lt: pol_actual_departure_lt
               pol: USHOU
-              pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-              pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt: pol_scheduled_departure_lt
+              pod_actual_arrival_lt: pod_actual_arrival_lt
+              pod_actual_discharge_lt: pod_actual_discharge_lt
+              pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
               pod_terminal_name: BARCELONA EUROPE SOUTH TERMINAL
               id: 94e3dc60-2039-4a54-a88c-7c5885fd7988
-              pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              pol_predicted_arrival_lt: pol_predicted_arrival_lt
+              pod_predicted_arrival_lt: pod_predicted_arrival_lt
               vessel_leg: 1
               is_active: true
-              pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+              pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
               created: 2000-01-23T04:56:07.000+00:00
               vessel_name: MAERSK PUELO
               pol_name: HOUSTON
               pod_name: BARCELONA
-              pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pod_predicted_departure_lt: pod_predicted_departure_lt
               pol_terminal_name: BAYPORT TERMINAL
-              pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_loading_lt: pol_scheduled_loading_lt
               carrier_no: CMDU
-              pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+              pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+              pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
               updated: 2000-01-23T04:56:07.000+00:00
-              pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-              pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+              pol_actual_loading_lt: pol_actual_loading_lt
+              pol_predicted_departure_lt: pol_predicted_departure_lt
             status_info:
               vessel:
                 metadata:
@@ -3487,19 +3461,19 @@ components:
             voyage_details:
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -3514,19 +3488,19 @@ components:
               port_code: ITGIT
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -3544,40 +3518,40 @@ components:
             sailing_info:
               vessel_flag: SG
               voyage_no: CG303R
-              pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
               pod: ESBCN
-              pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
+              pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
               imo: "9306172"
-              pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_departure_lt: pol_actual_departure_lt
               pol: USHOU
-              pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-              pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt: pol_scheduled_departure_lt
+              pod_actual_arrival_lt: pod_actual_arrival_lt
+              pod_actual_discharge_lt: pod_actual_discharge_lt
+              pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
               pod_terminal_name: BARCELONA EUROPE SOUTH TERMINAL
               id: 94e3dc60-2039-4a54-a88c-7c5885fd7988
-              pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              pol_predicted_arrival_lt: pol_predicted_arrival_lt
+              pod_predicted_arrival_lt: pod_predicted_arrival_lt
               vessel_leg: 1
               is_active: true
-              pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+              pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
               created: 2000-01-23T04:56:07.000+00:00
               vessel_name: MAERSK PUELO
               pol_name: HOUSTON
               pod_name: BARCELONA
-              pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pod_predicted_departure_lt: pod_predicted_departure_lt
               pol_terminal_name: BAYPORT TERMINAL
-              pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_loading_lt: pol_scheduled_loading_lt
               carrier_no: CMDU
-              pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+              pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+              pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
               updated: 2000-01-23T04:56:07.000+00:00
-              pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-              pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+              pol_actual_loading_lt: pol_actual_loading_lt
+              pol_predicted_departure_lt: pol_predicted_departure_lt
             status_info:
               vessel:
                 metadata:
@@ -3600,19 +3574,19 @@ components:
             voyage_details:
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -3627,19 +3601,19 @@ components:
               port_code: ITGIT
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -3669,42 +3643,42 @@ components:
           bill_of_lading:
             bl_no: COSU6349613240
             cntr_no: BMOU1589176
-            pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
             pod: GHTEM
-            pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
             place_of_delivery_name: NORFOLK
             place_of_receipt_name: TEMA
-            pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
-            pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
+            pol_actual_departure_lt: pol_actual_departure_lt
             pol: USORF
-            pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-            pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-            pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_departure_lt: pol_scheduled_departure_lt
+            pod_actual_arrival_lt: pod_actual_arrival_lt
+            pod_actual_discharge_lt: pod_actual_discharge_lt
+            pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
             pod_terminal_name: MERIDIAN PORT SERVICE LIMITED
             id: 16caa040-f582-4c15-88c9-2e80437e7916
-            pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+            pol_predicted_arrival_lt: pol_predicted_arrival_lt
+            pod_predicted_arrival_lt: pod_predicted_arrival_lt
             pol_scheduled_departure_lt_first_seen: pol_scheduled_departure_lt_first_seen
             place_of_delivery: USORF
-            pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+            pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
             created: 2000-01-23T04:56:07.000+00:00
             pol_name: NORFOLK
             pod_scheduled_arrival_lt_first_seen: pod_scheduled_arrival_lt_first_seen
             pod_name: TEMA
             place_of_receipt: GHTEM
-            pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pod_predicted_departure_lt: pod_predicted_departure_lt
             pol_terminal_name: PPCY EMPTY DEPOT
-            pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_loading_lt: pol_scheduled_loading_lt
             carrier_no: COSU
-            pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-            pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-            pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+            pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+            pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
             updated: 2000-01-23T04:56:07.000+00:00
-            pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-            pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-            pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+            pol_actual_loading_lt: pol_actual_loading_lt
+            pol_predicted_departure_lt: pol_predicted_departure_lt
           delay_lists:
           - port_name: XIAMEN
             reason_code: RLV
@@ -3824,40 +3798,40 @@ components:
             sailing_info:
               vessel_flag: SG
               voyage_no: CG303R
-              pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
               pod: ESBCN
-              pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
+              pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
               imo: "9306172"
-              pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_departure_lt: pol_actual_departure_lt
               pol: USHOU
-              pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-              pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt: pol_scheduled_departure_lt
+              pod_actual_arrival_lt: pod_actual_arrival_lt
+              pod_actual_discharge_lt: pod_actual_discharge_lt
+              pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
               pod_terminal_name: BARCELONA EUROPE SOUTH TERMINAL
               id: 94e3dc60-2039-4a54-a88c-7c5885fd7988
-              pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              pol_predicted_arrival_lt: pol_predicted_arrival_lt
+              pod_predicted_arrival_lt: pod_predicted_arrival_lt
               vessel_leg: 1
               is_active: true
-              pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+              pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
               created: 2000-01-23T04:56:07.000+00:00
               vessel_name: MAERSK PUELO
               pol_name: HOUSTON
               pod_name: BARCELONA
-              pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pod_predicted_departure_lt: pod_predicted_departure_lt
               pol_terminal_name: BAYPORT TERMINAL
-              pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_loading_lt: pol_scheduled_loading_lt
               carrier_no: CMDU
-              pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+              pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+              pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
               updated: 2000-01-23T04:56:07.000+00:00
-              pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-              pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+              pol_actual_loading_lt: pol_actual_loading_lt
+              pol_predicted_departure_lt: pol_predicted_departure_lt
             status_info:
               vessel:
                 metadata:
@@ -3880,19 +3854,19 @@ components:
             voyage_details:
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -3907,19 +3881,19 @@ components:
               port_code: ITGIT
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -3937,40 +3911,40 @@ components:
             sailing_info:
               vessel_flag: SG
               voyage_no: CG303R
-              pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
               pod: ESBCN
-              pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
+              pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
               imo: "9306172"
-              pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_departure_lt: pol_actual_departure_lt
               pol: USHOU
-              pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-              pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt: pol_scheduled_departure_lt
+              pod_actual_arrival_lt: pod_actual_arrival_lt
+              pod_actual_discharge_lt: pod_actual_discharge_lt
+              pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
               pod_terminal_name: BARCELONA EUROPE SOUTH TERMINAL
               id: 94e3dc60-2039-4a54-a88c-7c5885fd7988
-              pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              pol_predicted_arrival_lt: pol_predicted_arrival_lt
+              pod_predicted_arrival_lt: pod_predicted_arrival_lt
               vessel_leg: 1
               is_active: true
-              pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+              pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
               created: 2000-01-23T04:56:07.000+00:00
               vessel_name: MAERSK PUELO
               pol_name: HOUSTON
               pod_name: BARCELONA
-              pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pod_predicted_departure_lt: pod_predicted_departure_lt
               pol_terminal_name: BAYPORT TERMINAL
-              pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_loading_lt: pol_scheduled_loading_lt
               carrier_no: CMDU
-              pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+              pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+              pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
               updated: 2000-01-23T04:56:07.000+00:00
-              pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-              pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+              pol_actual_loading_lt: pol_actual_loading_lt
+              pol_predicted_departure_lt: pol_predicted_departure_lt
             status_info:
               vessel:
                 metadata:
@@ -3993,19 +3967,19 @@ components:
             voyage_details:
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -4020,19 +3994,19 @@ components:
               port_code: ITGIT
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -4062,42 +4036,42 @@ components:
           bill_of_lading:
             bl_no: COSU6349613240
             cntr_no: BMOU1589176
-            pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
             pod: GHTEM
-            pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
             place_of_delivery_name: NORFOLK
             place_of_receipt_name: TEMA
-            pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
-            pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
+            pol_actual_departure_lt: pol_actual_departure_lt
             pol: USORF
-            pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-            pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-            pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_departure_lt: pol_scheduled_departure_lt
+            pod_actual_arrival_lt: pod_actual_arrival_lt
+            pod_actual_discharge_lt: pod_actual_discharge_lt
+            pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
             pod_terminal_name: MERIDIAN PORT SERVICE LIMITED
             id: 16caa040-f582-4c15-88c9-2e80437e7916
-            pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+            pol_predicted_arrival_lt: pol_predicted_arrival_lt
+            pod_predicted_arrival_lt: pod_predicted_arrival_lt
             pol_scheduled_departure_lt_first_seen: pol_scheduled_departure_lt_first_seen
             place_of_delivery: USORF
-            pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+            pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
             created: 2000-01-23T04:56:07.000+00:00
             pol_name: NORFOLK
             pod_scheduled_arrival_lt_first_seen: pod_scheduled_arrival_lt_first_seen
             pod_name: TEMA
             place_of_receipt: GHTEM
-            pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pod_predicted_departure_lt: pod_predicted_departure_lt
             pol_terminal_name: PPCY EMPTY DEPOT
-            pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_loading_lt: pol_scheduled_loading_lt
             carrier_no: COSU
-            pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-            pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-            pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+            pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+            pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
             updated: 2000-01-23T04:56:07.000+00:00
-            pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-            pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-            pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+            pol_actual_loading_lt: pol_actual_loading_lt
+            pol_predicted_departure_lt: pol_predicted_departure_lt
           delay_lists:
           - port_name: XIAMEN
             reason_code: RLV
@@ -4217,40 +4191,40 @@ components:
             sailing_info:
               vessel_flag: SG
               voyage_no: CG303R
-              pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
               pod: ESBCN
-              pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
+              pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
               imo: "9306172"
-              pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_departure_lt: pol_actual_departure_lt
               pol: USHOU
-              pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-              pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt: pol_scheduled_departure_lt
+              pod_actual_arrival_lt: pod_actual_arrival_lt
+              pod_actual_discharge_lt: pod_actual_discharge_lt
+              pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
               pod_terminal_name: BARCELONA EUROPE SOUTH TERMINAL
               id: 94e3dc60-2039-4a54-a88c-7c5885fd7988
-              pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              pol_predicted_arrival_lt: pol_predicted_arrival_lt
+              pod_predicted_arrival_lt: pod_predicted_arrival_lt
               vessel_leg: 1
               is_active: true
-              pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+              pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
               created: 2000-01-23T04:56:07.000+00:00
               vessel_name: MAERSK PUELO
               pol_name: HOUSTON
               pod_name: BARCELONA
-              pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pod_predicted_departure_lt: pod_predicted_departure_lt
               pol_terminal_name: BAYPORT TERMINAL
-              pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_loading_lt: pol_scheduled_loading_lt
               carrier_no: CMDU
-              pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+              pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+              pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
               updated: 2000-01-23T04:56:07.000+00:00
-              pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-              pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+              pol_actual_loading_lt: pol_actual_loading_lt
+              pol_predicted_departure_lt: pol_predicted_departure_lt
             status_info:
               vessel:
                 metadata:
@@ -4273,19 +4247,19 @@ components:
             voyage_details:
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -4300,19 +4274,19 @@ components:
               port_code: ITGIT
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -4330,40 +4304,40 @@ components:
             sailing_info:
               vessel_flag: SG
               voyage_no: CG303R
-              pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
               pod: ESBCN
-              pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
+              pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
               imo: "9306172"
-              pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_departure_lt: pol_actual_departure_lt
               pol: USHOU
-              pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-              pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt: pol_scheduled_departure_lt
+              pod_actual_arrival_lt: pod_actual_arrival_lt
+              pod_actual_discharge_lt: pod_actual_discharge_lt
+              pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
               pod_terminal_name: BARCELONA EUROPE SOUTH TERMINAL
               id: 94e3dc60-2039-4a54-a88c-7c5885fd7988
-              pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              pol_predicted_arrival_lt: pol_predicted_arrival_lt
+              pod_predicted_arrival_lt: pod_predicted_arrival_lt
               vessel_leg: 1
               is_active: true
-              pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+              pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
               created: 2000-01-23T04:56:07.000+00:00
               vessel_name: MAERSK PUELO
               pol_name: HOUSTON
               pod_name: BARCELONA
-              pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pod_predicted_departure_lt: pod_predicted_departure_lt
               pol_terminal_name: BAYPORT TERMINAL
-              pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_loading_lt: pol_scheduled_loading_lt
               carrier_no: CMDU
-              pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+              pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+              pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
               updated: 2000-01-23T04:56:07.000+00:00
-              pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-              pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+              pol_actual_loading_lt: pol_actual_loading_lt
+              pol_predicted_departure_lt: pol_predicted_departure_lt
             status_info:
               vessel:
                 metadata:
@@ -4386,19 +4360,19 @@ components:
             voyage_details:
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -4413,19 +4387,19 @@ components:
               port_code: ITGIT
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -4455,42 +4429,42 @@ components:
           bill_of_lading:
             bl_no: COSU6349613240
             cntr_no: BMOU1589176
-            pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
             pod: GHTEM
-            pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
             place_of_delivery_name: NORFOLK
             place_of_receipt_name: TEMA
-            pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
-            pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
+            pol_actual_departure_lt: pol_actual_departure_lt
             pol: USORF
-            pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-            pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-            pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_departure_lt: pol_scheduled_departure_lt
+            pod_actual_arrival_lt: pod_actual_arrival_lt
+            pod_actual_discharge_lt: pod_actual_discharge_lt
+            pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
             pod_terminal_name: MERIDIAN PORT SERVICE LIMITED
             id: 16caa040-f582-4c15-88c9-2e80437e7916
-            pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+            pol_predicted_arrival_lt: pol_predicted_arrival_lt
+            pod_predicted_arrival_lt: pod_predicted_arrival_lt
             pol_scheduled_departure_lt_first_seen: pol_scheduled_departure_lt_first_seen
             place_of_delivery: USORF
-            pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+            pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
             created: 2000-01-23T04:56:07.000+00:00
             pol_name: NORFOLK
             pod_scheduled_arrival_lt_first_seen: pod_scheduled_arrival_lt_first_seen
             pod_name: TEMA
             place_of_receipt: GHTEM
-            pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pod_predicted_departure_lt: pod_predicted_departure_lt
             pol_terminal_name: PPCY EMPTY DEPOT
-            pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_loading_lt: pol_scheduled_loading_lt
             carrier_no: COSU
-            pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-            pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-            pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+            pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+            pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
             updated: 2000-01-23T04:56:07.000+00:00
-            pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-            pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-            pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+            pol_actual_loading_lt: pol_actual_loading_lt
+            pol_predicted_departure_lt: pol_predicted_departure_lt
           delay_lists:
           - port_name: XIAMEN
             reason_code: RLV
@@ -4638,40 +4612,40 @@ components:
             sailing_info:
               vessel_flag: SG
               voyage_no: CG303R
-              pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
               pod: ESBCN
-              pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
+              pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
               imo: "9306172"
-              pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_departure_lt: pol_actual_departure_lt
               pol: USHOU
-              pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-              pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt: pol_scheduled_departure_lt
+              pod_actual_arrival_lt: pod_actual_arrival_lt
+              pod_actual_discharge_lt: pod_actual_discharge_lt
+              pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
               pod_terminal_name: BARCELONA EUROPE SOUTH TERMINAL
               id: 94e3dc60-2039-4a54-a88c-7c5885fd7988
-              pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              pol_predicted_arrival_lt: pol_predicted_arrival_lt
+              pod_predicted_arrival_lt: pod_predicted_arrival_lt
               vessel_leg: 1
               is_active: true
-              pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+              pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
               created: 2000-01-23T04:56:07.000+00:00
               vessel_name: MAERSK PUELO
               pol_name: HOUSTON
               pod_name: BARCELONA
-              pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pod_predicted_departure_lt: pod_predicted_departure_lt
               pol_terminal_name: BAYPORT TERMINAL
-              pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_loading_lt: pol_scheduled_loading_lt
               carrier_no: CMDU
-              pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+              pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+              pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
               updated: 2000-01-23T04:56:07.000+00:00
-              pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-              pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+              pol_actual_loading_lt: pol_actual_loading_lt
+              pol_predicted_departure_lt: pol_predicted_departure_lt
             status_info:
               vessel:
                 metadata:
@@ -4694,19 +4668,19 @@ components:
             voyage_details:
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -4721,19 +4695,19 @@ components:
               port_code: ITGIT
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -4751,40 +4725,40 @@ components:
             sailing_info:
               vessel_flag: SG
               voyage_no: CG303R
-              pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
               pod: ESBCN
-              pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
+              pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
               imo: "9306172"
-              pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_departure_lt: pol_actual_departure_lt
               pol: USHOU
-              pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-              pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt: pol_scheduled_departure_lt
+              pod_actual_arrival_lt: pod_actual_arrival_lt
+              pod_actual_discharge_lt: pod_actual_discharge_lt
+              pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
               pod_terminal_name: BARCELONA EUROPE SOUTH TERMINAL
               id: 94e3dc60-2039-4a54-a88c-7c5885fd7988
-              pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              pol_predicted_arrival_lt: pol_predicted_arrival_lt
+              pod_predicted_arrival_lt: pod_predicted_arrival_lt
               vessel_leg: 1
               is_active: true
-              pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+              pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+              pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
               created: 2000-01-23T04:56:07.000+00:00
               vessel_name: MAERSK PUELO
               pol_name: HOUSTON
               pod_name: BARCELONA
-              pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pod_predicted_departure_lt: pod_predicted_departure_lt
               pol_terminal_name: BAYPORT TERMINAL
-              pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_loading_lt: pol_scheduled_loading_lt
               carrier_no: CMDU
-              pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-              pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+              pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+              pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+              pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
               updated: 2000-01-23T04:56:07.000+00:00
-              pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-              pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-              pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+              pol_actual_loading_lt: pol_actual_loading_lt
+              pol_predicted_departure_lt: pol_predicted_departure_lt
             status_info:
               vessel:
                 metadata:
@@ -4807,19 +4781,19 @@ components:
             voyage_details:
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -4834,19 +4808,19 @@ components:
               port_code: ITGIT
             - actual_arrival_utc: 2000-01-23T04:56:07.000+00:00
               timezone: UTC +2
-              predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_departure_lt: predicted_departure_lt
               index: 1
               lon: 15.901825
-              predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-              actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+              predicted_arrival_lt: predicted_arrival_lt
+              scheduled_arrival_lt: scheduled_arrival_lt
+              actual_departure_lt: actual_departure_lt
               port_name: GIOIA TAURO
               scheduled_departure_utc: 2000-01-23T04:56:07.000+00:00
               prediction_time_utc: 2000-01-23T04:56:07.000+00:00
-              actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
+              actual_arrival_lt: actual_arrival_lt
               predicted_arrival_utc: 2000-01-23T04:56:07.000+00:00
               scheduled_arrival_utc: 2000-01-23T04:56:07.000+00:00
-              scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
+              scheduled_departure_lt: scheduled_departure_lt
               actual_departure_utc: 2000-01-23T04:56:07.000+00:00
               voyage_no_list:
               - CG303R
@@ -4876,42 +4850,42 @@ components:
           bill_of_lading:
             bl_no: COSU6349613240
             cntr_no: BMOU1589176
-            pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
             pod: GHTEM
-            pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
             place_of_delivery_name: NORFOLK
             place_of_receipt_name: TEMA
-            pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
-            pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
+            pol_actual_departure_lt: pol_actual_departure_lt
             pol: USORF
-            pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-            pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-            pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_departure_lt: pol_scheduled_departure_lt
+            pod_actual_arrival_lt: pod_actual_arrival_lt
+            pod_actual_discharge_lt: pod_actual_discharge_lt
+            pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
             pod_terminal_name: MERIDIAN PORT SERVICE LIMITED
             id: 16caa040-f582-4c15-88c9-2e80437e7916
-            pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+            pol_predicted_arrival_lt: pol_predicted_arrival_lt
+            pod_predicted_arrival_lt: pod_predicted_arrival_lt
             pol_scheduled_departure_lt_first_seen: pol_scheduled_departure_lt_first_seen
             place_of_delivery: USORF
-            pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-            pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+            pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+            pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
             created: 2000-01-23T04:56:07.000+00:00
             pol_name: NORFOLK
             pod_scheduled_arrival_lt_first_seen: pod_scheduled_arrival_lt_first_seen
             pod_name: TEMA
             place_of_receipt: GHTEM
-            pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pod_predicted_departure_lt: pod_predicted_departure_lt
             pol_terminal_name: PPCY EMPTY DEPOT
-            pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_loading_lt: pol_scheduled_loading_lt
             carrier_no: COSU
-            pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-            pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-            pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+            pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+            pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+            pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
             updated: 2000-01-23T04:56:07.000+00:00
-            pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-            pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-            pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+            pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+            pol_actual_loading_lt: pol_actual_loading_lt
+            pol_predicted_departure_lt: pol_predicted_departure_lt
           delay_lists:
           - port_name: XIAMEN
             reason_code: RLV
@@ -5378,40 +5352,40 @@ components:
       example:
         vessel_flag: SG
         voyage_no: CG303R
-        pol_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+        pol_scheduled_arrival_lt_from_schedule: pol_scheduled_arrival_lt_from_schedule
         pod: ESBCN
-        pod_scheduled_arrival_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-        pod_scheduled_discharge_lt: 2000-01-23T04:56:07.000+00:00
+        pod_scheduled_arrival_lt_from_schedule: pod_scheduled_arrival_lt_from_schedule
+        pod_scheduled_discharge_lt: pod_scheduled_discharge_lt
         imo: "9306172"
-        pol_actual_departure_lt: 2000-01-23T04:56:07.000+00:00
+        pol_actual_departure_lt: pol_actual_departure_lt
         pol: USHOU
-        pol_scheduled_departure_lt: 2000-01-23T04:56:07.000+00:00
-        pod_actual_arrival_lt: 2000-01-23T04:56:07.000+00:00
-        pod_actual_discharge_lt: 2000-01-23T04:56:07.000+00:00
-        pol_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+        pol_scheduled_departure_lt: pol_scheduled_departure_lt
+        pod_actual_arrival_lt: pod_actual_arrival_lt
+        pod_actual_discharge_lt: pod_actual_discharge_lt
+        pol_actual_departure_lt_from_ais: pol_actual_departure_lt_from_ais
         pod_terminal_name: BARCELONA EUROPE SOUTH TERMINAL
         id: 94e3dc60-2039-4a54-a88c-7c5885fd7988
-        pol_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
-        pod_predicted_arrival_lt: 2000-01-23T04:56:07.000+00:00
+        pol_predicted_arrival_lt: pol_predicted_arrival_lt
+        pod_predicted_arrival_lt: pod_predicted_arrival_lt
         vessel_leg: 1
         is_active: true
-        pod_scheduled_arrival_lt: 2000-01-23T04:56:07.000+00:00
-        pod_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
+        pod_scheduled_arrival_lt: pod_scheduled_arrival_lt
+        pod_scheduled_departure_lt_from_schedule: pod_scheduled_departure_lt_from_schedule
         created: 2000-01-23T04:56:07.000+00:00
         vessel_name: MAERSK PUELO
         pol_name: HOUSTON
         pod_name: BARCELONA
-        pod_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+        pod_predicted_departure_lt: pod_predicted_departure_lt
         pol_terminal_name: BAYPORT TERMINAL
-        pol_scheduled_loading_lt: 2000-01-23T04:56:07.000+00:00
+        pol_scheduled_loading_lt: pol_scheduled_loading_lt
         carrier_no: CMDU
-        pol_scheduled_departure_lt_from_schedule: 2000-01-23T04:56:07.000+00:00
-        pod_actual_departure_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-        pod_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
+        pol_scheduled_departure_lt_from_schedule: pol_scheduled_departure_lt_from_schedule
+        pod_actual_departure_lt_from_ais: pod_actual_departure_lt_from_ais
+        pod_actual_arrival_lt_from_ais: pod_actual_arrival_lt_from_ais
         updated: 2000-01-23T04:56:07.000+00:00
-        pol_actual_arrival_lt_from_ais: 2000-01-23T04:56:07.000+00:00
-        pol_actual_loading_lt: 2000-01-23T04:56:07.000+00:00
-        pol_predicted_departure_lt: 2000-01-23T04:56:07.000+00:00
+        pol_actual_arrival_lt_from_ais: pol_actual_arrival_lt_from_ais
+        pol_actual_loading_lt: pol_actual_loading_lt
+        pol_predicted_departure_lt: pol_predicted_departure_lt
       properties:
         carrier_no:
           description: Carrier SCAC Code
@@ -5444,25 +5418,21 @@ components:
           type: string
         pod_actual_arrival_lt:
           description: Actual Arrival Time at the target port location - Local Time
-          format: date-time
           nullable: true
           type: string
         pod_actual_arrival_lt_from_ais:
           description: Actual Arrival Time at the target port location as per AIS
             Data - Local Time
-          format: date-time
           nullable: true
           type: string
         pod_actual_departure_lt_from_ais:
           description: Actual Departure Time from the target port location as per
             AIS Data - Local Time
-          format: date-time
           nullable: true
           type: string
         pod_actual_discharge_lt:
           description: Actual Time of Discharge at the target port location - Local
             Time
-          format: date-time
           nullable: true
           type: string
         pod_name:
@@ -5473,37 +5443,31 @@ components:
         pod_predicted_arrival_lt:
           description: Portcast Predicted Time of Arrival at the target port location
             - Local Time
-          format: date-time
           nullable: true
           type: string
         pod_predicted_departure_lt:
           description: Portcast Predicted Time of Departure from the target port location
             - Local Time
-          format: date-time
           nullable: true
           type: string
         pod_scheduled_arrival_lt:
           description: Scheduled Time of Arrival at the target port location - Local
             Time
-          format: date-time
           nullable: true
           type: string
         pod_scheduled_arrival_lt_from_schedule:
           description: Scheduled Time of Arrival at the target port location as per
             Vessel Schedule - Local Time
-          format: date-time
           nullable: true
           type: string
         pod_scheduled_departure_lt_from_schedule:
           description: Scheduled Time of Departure from the target port location as
             per Vessel Schedule - Local Time
-          format: date-time
           nullable: true
           type: string
         pod_scheduled_discharge_lt:
           description: Scheduled Discharge Time at the target port location - Local
             Time
-          format: date-time
           nullable: true
           type: string
         pod_terminal_name:
@@ -5520,24 +5484,20 @@ components:
         pol_actual_arrival_lt_from_ais:
           description: Actual Time of Arrival at the starting port location as per
             AIS Data - Local Time
-          format: date-time
           nullable: true
           type: string
         pol_actual_departure_lt:
           description: Actual Time of Departure from the starting port location -
             Local Time
-          format: date-time
           nullable: true
           type: string
         pol_actual_departure_lt_from_ais:
           description: Actual Time of Departure from the starting port location as
             per AIS Data - Local Time
-          format: date-time
           nullable: true
           type: string
         pol_actual_loading_lt:
           description: Actual Loading Time at the starting port location - Local Time
-          format: date-time
           nullable: true
           type: string
         pol_name:
@@ -5548,37 +5508,31 @@ components:
         pol_predicted_arrival_lt:
           description: Portcast Predicted Time of Arrival at the starting port location
             - Local Time
-          format: date-time
           nullable: true
           type: string
         pol_predicted_departure_lt:
           description: Portcast Predicted Time of Departure from the starting port
             location - Local Time
-          format: date-time
           nullable: true
           type: string
         pol_scheduled_arrival_lt_from_schedule:
           description: Scheduled Time of Arrival at the starting port location as
             per Vessel Schedule- Local Time
-          format: date-time
           nullable: true
           type: string
         pol_scheduled_departure_lt:
           description: Scheduled Time of Departure from the starting port location
             - Local Time
-          format: date-time
           nullable: true
           type: string
         pol_scheduled_departure_lt_from_schedule:
           description: Scheduled Time of Departure from the starting port location
             as per Vessel Schedule - Local Time
-          format: date-time
           nullable: true
           type: string
         pol_scheduled_loading_lt:
           description: Scheduled Loading Time at the starting port location - Local
             Time
-          format: date-time
           nullable: true
           type: string
         pol_terminal_name:
@@ -5970,7 +5924,7 @@ components:
         gate_in_date: 2023-06-21T14:15:22Z
         port_cutoff_standard: 2023-06-23T14:15:22Z
         erd_reefer: 2023-06-24T14:15:22Z
-        actual_departure: 2000-01-23T04:56:07.000+00:00
+        actual_departure: actual_departure
         id: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
         updated: 2000-01-23T04:56:07.000+00:00
         port_code: SGSIN
@@ -6013,13 +5967,11 @@ components:
           description: "Earliest Receipt Date (ERD) for a standard container, as reported\
             \ by the terminal - Local Time."
           example: 2023-06-24T14:15:22Z
-          format: date-time
           type: string
         erd_reefer:
           description: "Earliest Receipt Date (ERD) for a reefer container, as reported\
             \ by the terminal - Local Time."
           example: 2023-06-24T14:15:22Z
-          format: date-time
           type: string
         gate_in_date:
           description: "Date a container was received at the terminal through the\
@@ -6030,36 +5982,30 @@ components:
           description: "Last possible date and time for gating-in standard container\
             \ at the export terminal, as reported by the Terminal - Local Time."
           example: 2023-06-23T14:15:22Z
-          format: date-time
           type: string
         port_cutoff_reefer:
           description: "Last possible date and time for gating-in reefer container\
             \ at the export terminal, as reported by the terminal - Local Time."
           example: 2023-06-23T14:15:22Z
-          format: date-time
           type: string
         latest_eta:
           description: "Latest vessel ETA to the export port, as reported by the terminal\
             \ - Local Time."
           example: 2023-06-24T14:15:22Z
-          format: date-time
           type: string
         actual_arrival:
           description: "Actual vessel time of arrival, as reported by the terminal\
             \ - Local Time."
           example: 2023-06-24T14:15:22Z
-          format: date-time
           type: string
         latest_etd:
           description: "Latest vessel ETD from the export port, as reported by the\
             \ terminal - Local Time."
           example: 2023-06-26T14:15:22Z
-          format: date-time
           type: string
         actual_departure:
           description: "Actual vessel time of departure from the export port, as reported\
             \ by the terminal - Local Time."
-          format: date-time
           pattern: 2023-06-26T14:15:22Z
           type: string
     Port_Terminal_Add_On_import_plan:

--- a/portcast/docs/BillOfLading.md
+++ b/portcast/docs/BillOfLading.md
@@ -14,32 +14,32 @@ Name | Type | Description | Notes
 **PlaceOfReceipt** | Pointer to **string** | UNLOCODE for the Location of Container Receipt (Before the POL) | [optional] 
 **PlaceOfReceiptName** | Pointer to **string** | Name for the Location of Container Receipt (Before the POL) | [optional] 
 **Pod** | Pointer to **string** | UNLOCODE for the Port of Discharge | [optional] 
-**PodActualArrivalLt** | Pointer to **NullableTime** | Actual Time of Arrival for the Final Vessel at the Port of Discharge (POD) - Local Time | [optional] 
-**PodActualArrivalLtFromAis** | Pointer to **NullableTime** | Actual Time of Arrival for the Final Vessel at the Port of Discharge (POD) as per AIS Data- Local Time | [optional] 
-**PodActualDepartureLtFromAis** | Pointer to **NullableTime** | Actual Time of Departure for the Final Vessel from the Port of Discharge (POD) as per AIS Data - Local Time | [optional] 
-**PodActualDischargeLt** | Pointer to **NullableTime** | Actual Container Discharge Time from Final Vessel at the Port of Discharge (POD) - Local Time | [optional] 
+**PodActualArrivalLt** | Pointer to **NullableString** | Actual Time of Arrival for the Final Vessel at the Port of Discharge (POD) - Local Time | [optional] 
+**PodActualArrivalLtFromAis** | Pointer to **NullableString** | Actual Time of Arrival for the Final Vessel at the Port of Discharge (POD) as per AIS Data- Local Time | [optional] 
+**PodActualDepartureLtFromAis** | Pointer to **NullableString** | Actual Time of Departure for the Final Vessel from the Port of Discharge (POD) as per AIS Data - Local Time | [optional] 
+**PodActualDischargeLt** | Pointer to **NullableString** | Actual Container Discharge Time from Final Vessel at the Port of Discharge (POD) - Local Time | [optional] 
 **PodName** | Pointer to **string** | Port of Discharge Name | [optional] 
-**PodPredictedArrivalLt** | Pointer to **NullableTime** | Portcast Predicted Time of Arrival for the Final Vessel at the Port of Discharge (POD) - Local Time [Most Reliable Source of ETA] | [optional] 
-**PodPredictedDepartureLt** | Pointer to **NullableTime** | Portcast Predicted Time of Departure for the Final Vessel from the Port of Discharge (POD) - Local Time | [optional] 
-**PodScheduledArrivalLt** | Pointer to **NullableTime** | Scheduled Time of Arrival for the Final Vessel at the Port of Discharge (POD) as per carrier T&amp;T - Local Time | [optional] 
+**PodPredictedArrivalLt** | Pointer to **NullableString** | Portcast Predicted Time of Arrival for the Final Vessel at the Port of Discharge (POD) - Local Time [Most Reliable Source of ETA] | [optional] 
+**PodPredictedDepartureLt** | Pointer to **NullableString** | Portcast Predicted Time of Departure for the Final Vessel from the Port of Discharge (POD) - Local Time | [optional] 
+**PodScheduledArrivalLt** | Pointer to **NullableString** | Scheduled Time of Arrival for the Final Vessel at the Port of Discharge (POD) as per carrier T&amp;T - Local Time | [optional] 
 **PodScheduledArrivalLtFirstSeen** | Pointer to **NullableString** | First Recorded Scheduled Time of Arrival for the Final Vessel at the Port of Discharge (POD) as per carrier T&amp;T - Local Time | [optional] 
-**PodScheduledArrivalLtFromSchedule** | Pointer to **NullableTime** | Scheduled Time of Arrival for the Final Vessel at the Port of Discharge (POD) as per vessel schedule - Local Time | [optional] 
-**PodScheduledDepartureLtFromSchedule** | Pointer to **NullableTime** | Scheduled Time of Departure for the Final Vessel from the Port of Discharge (POD) as per vessel schedule - Local Time | [optional] 
-**PodScheduledDischargeLt** | Pointer to **NullableTime** | Carrier Scheduled Container Discharge Time from Final Vessel at the Port of Discharge (POD) - Local Time | [optional] 
+**PodScheduledArrivalLtFromSchedule** | Pointer to **NullableString** | Scheduled Time of Arrival for the Final Vessel at the Port of Discharge (POD) as per vessel schedule - Local Time | [optional] 
+**PodScheduledDepartureLtFromSchedule** | Pointer to **NullableString** | Scheduled Time of Departure for the Final Vessel from the Port of Discharge (POD) as per vessel schedule - Local Time | [optional] 
+**PodScheduledDischargeLt** | Pointer to **NullableString** | Carrier Scheduled Container Discharge Time from Final Vessel at the Port of Discharge (POD) - Local Time | [optional] 
 **PodTerminalName** | Pointer to **string** | Terminal Name for the Port of Discharge (POD) | [optional] 
 **Pol** | Pointer to **string** | UNLOCODE for the Port of Loading | [optional] 
-**PolActualArrivalLtFromAis** | Pointer to **NullableTime** | Actual Time of Arrival for the First Vessel at the Port of Loading (POL) as per AIS Data - Local Time | [optional] 
-**PolActualDepartureLt** | Pointer to **NullableTime** | Actual Time of Departure for the First Vessel from the Port of Loading (POL) - Local Time | [optional] 
-**PolActualDepartureLtFromAis** | Pointer to **NullableTime** | Actual Time of Departure for the First Vessel from the Port of Loading (POL) as per AIS Data - Local Time | [optional] 
-**PolActualLoadingLt** | Pointer to **NullableTime** | Actual Container Loading Time on First Vessel at the Port of Loading (POL) - Local Time | [optional] 
+**PolActualArrivalLtFromAis** | Pointer to **NullableString** | Actual Time of Arrival for the First Vessel at the Port of Loading (POL) as per AIS Data - Local Time | [optional] 
+**PolActualDepartureLt** | Pointer to **NullableString** | Actual Time of Departure for the First Vessel from the Port of Loading (POL) - Local Time | [optional] 
+**PolActualDepartureLtFromAis** | Pointer to **NullableString** | Actual Time of Departure for the First Vessel from the Port of Loading (POL) as per AIS Data - Local Time | [optional] 
+**PolActualLoadingLt** | Pointer to **NullableString** | Actual Container Loading Time on First Vessel at the Port of Loading (POL) - Local Time | [optional] 
 **PolName** | Pointer to **string** | Port of Loading Name | [optional] 
-**PolPredictedArrivalLt** | Pointer to **NullableTime** | Portcast Predicted Time of Arrival for the First Vessel at the Port of Loading (POL) - Local Time | [optional] 
-**PolPredictedDepartureLt** | Pointer to **NullableTime** | Portcast Predicted Time of Departure for the First Vessel from the Port of Loading (POL) - Local Time [Most Reliable Source of ETD] | [optional] 
-**PolScheduledArrivalLtFromSchedule** | Pointer to **NullableTime** | Scheduled Time of Arrival for the First Vessel at the Port of Loading (POL) as per Vessel Schedule - Local Time | [optional] 
-**PolScheduledDepartureLt** | Pointer to **NullableTime** | Scheduled Time of Departure for the First Vessel from the Port of Loading (POL) as per Container T&amp;T - Local Time | [optional] 
+**PolPredictedArrivalLt** | Pointer to **NullableString** | Portcast Predicted Time of Arrival for the First Vessel at the Port of Loading (POL) - Local Time | [optional] 
+**PolPredictedDepartureLt** | Pointer to **NullableString** | Portcast Predicted Time of Departure for the First Vessel from the Port of Loading (POL) - Local Time [Most Reliable Source of ETD] | [optional] 
+**PolScheduledArrivalLtFromSchedule** | Pointer to **NullableString** | Scheduled Time of Arrival for the First Vessel at the Port of Loading (POL) as per Vessel Schedule - Local Time | [optional] 
+**PolScheduledDepartureLt** | Pointer to **NullableString** | Scheduled Time of Departure for the First Vessel from the Port of Loading (POL) as per Container T&amp;T - Local Time | [optional] 
 **PolScheduledDepartureLtFirstSeen** | Pointer to **NullableString** | First Recorded Scheduled Time of Departure for the First Vessel at the Port of Loading (POL) as per carrier T&amp;T - Local Time | [optional] 
-**PolScheduledDepartureLtFromSchedule** | Pointer to **NullableTime** | Scheduled Time of Departure for the First Vessel from the Port of Loading (POL) as per Vessel Schedule - Local Time | [optional] 
-**PolScheduledLoadingLt** | Pointer to **NullableTime** | Carrier Scheduled Container Loading Time on First Vessel at the Port of Loading (POL) - Local Time | [optional] 
+**PolScheduledDepartureLtFromSchedule** | Pointer to **NullableString** | Scheduled Time of Departure for the First Vessel from the Port of Loading (POL) as per Vessel Schedule - Local Time | [optional] 
+**PolScheduledLoadingLt** | Pointer to **NullableString** | Carrier Scheduled Container Loading Time on First Vessel at the Port of Loading (POL) - Local Time | [optional] 
 **PolTerminalName** | Pointer to **string** | Terminal Name for the Port of Loading (POL) | [optional] 
 **Updated** | Pointer to **time.Time** | Bill of Lading Object Updated Date | [optional] 
 
@@ -314,20 +314,20 @@ HasPod returns a boolean if a field has been set.
 
 ### GetPodActualArrivalLt
 
-`func (o *BillOfLading) GetPodActualArrivalLt() time.Time`
+`func (o *BillOfLading) GetPodActualArrivalLt() string`
 
 GetPodActualArrivalLt returns the PodActualArrivalLt field if non-nil, zero value otherwise.
 
 ### GetPodActualArrivalLtOk
 
-`func (o *BillOfLading) GetPodActualArrivalLtOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPodActualArrivalLtOk() (*string, bool)`
 
 GetPodActualArrivalLtOk returns a tuple with the PodActualArrivalLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodActualArrivalLt
 
-`func (o *BillOfLading) SetPodActualArrivalLt(v time.Time)`
+`func (o *BillOfLading) SetPodActualArrivalLt(v string)`
 
 SetPodActualArrivalLt sets PodActualArrivalLt field to given value.
 
@@ -349,20 +349,20 @@ HasPodActualArrivalLt returns a boolean if a field has been set.
 UnsetPodActualArrivalLt ensures that no value is present for PodActualArrivalLt, not even an explicit nil
 ### GetPodActualArrivalLtFromAis
 
-`func (o *BillOfLading) GetPodActualArrivalLtFromAis() time.Time`
+`func (o *BillOfLading) GetPodActualArrivalLtFromAis() string`
 
 GetPodActualArrivalLtFromAis returns the PodActualArrivalLtFromAis field if non-nil, zero value otherwise.
 
 ### GetPodActualArrivalLtFromAisOk
 
-`func (o *BillOfLading) GetPodActualArrivalLtFromAisOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPodActualArrivalLtFromAisOk() (*string, bool)`
 
 GetPodActualArrivalLtFromAisOk returns a tuple with the PodActualArrivalLtFromAis field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodActualArrivalLtFromAis
 
-`func (o *BillOfLading) SetPodActualArrivalLtFromAis(v time.Time)`
+`func (o *BillOfLading) SetPodActualArrivalLtFromAis(v string)`
 
 SetPodActualArrivalLtFromAis sets PodActualArrivalLtFromAis field to given value.
 
@@ -384,20 +384,20 @@ HasPodActualArrivalLtFromAis returns a boolean if a field has been set.
 UnsetPodActualArrivalLtFromAis ensures that no value is present for PodActualArrivalLtFromAis, not even an explicit nil
 ### GetPodActualDepartureLtFromAis
 
-`func (o *BillOfLading) GetPodActualDepartureLtFromAis() time.Time`
+`func (o *BillOfLading) GetPodActualDepartureLtFromAis() string`
 
 GetPodActualDepartureLtFromAis returns the PodActualDepartureLtFromAis field if non-nil, zero value otherwise.
 
 ### GetPodActualDepartureLtFromAisOk
 
-`func (o *BillOfLading) GetPodActualDepartureLtFromAisOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPodActualDepartureLtFromAisOk() (*string, bool)`
 
 GetPodActualDepartureLtFromAisOk returns a tuple with the PodActualDepartureLtFromAis field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodActualDepartureLtFromAis
 
-`func (o *BillOfLading) SetPodActualDepartureLtFromAis(v time.Time)`
+`func (o *BillOfLading) SetPodActualDepartureLtFromAis(v string)`
 
 SetPodActualDepartureLtFromAis sets PodActualDepartureLtFromAis field to given value.
 
@@ -419,20 +419,20 @@ HasPodActualDepartureLtFromAis returns a boolean if a field has been set.
 UnsetPodActualDepartureLtFromAis ensures that no value is present for PodActualDepartureLtFromAis, not even an explicit nil
 ### GetPodActualDischargeLt
 
-`func (o *BillOfLading) GetPodActualDischargeLt() time.Time`
+`func (o *BillOfLading) GetPodActualDischargeLt() string`
 
 GetPodActualDischargeLt returns the PodActualDischargeLt field if non-nil, zero value otherwise.
 
 ### GetPodActualDischargeLtOk
 
-`func (o *BillOfLading) GetPodActualDischargeLtOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPodActualDischargeLtOk() (*string, bool)`
 
 GetPodActualDischargeLtOk returns a tuple with the PodActualDischargeLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodActualDischargeLt
 
-`func (o *BillOfLading) SetPodActualDischargeLt(v time.Time)`
+`func (o *BillOfLading) SetPodActualDischargeLt(v string)`
 
 SetPodActualDischargeLt sets PodActualDischargeLt field to given value.
 
@@ -479,20 +479,20 @@ HasPodName returns a boolean if a field has been set.
 
 ### GetPodPredictedArrivalLt
 
-`func (o *BillOfLading) GetPodPredictedArrivalLt() time.Time`
+`func (o *BillOfLading) GetPodPredictedArrivalLt() string`
 
 GetPodPredictedArrivalLt returns the PodPredictedArrivalLt field if non-nil, zero value otherwise.
 
 ### GetPodPredictedArrivalLtOk
 
-`func (o *BillOfLading) GetPodPredictedArrivalLtOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPodPredictedArrivalLtOk() (*string, bool)`
 
 GetPodPredictedArrivalLtOk returns a tuple with the PodPredictedArrivalLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodPredictedArrivalLt
 
-`func (o *BillOfLading) SetPodPredictedArrivalLt(v time.Time)`
+`func (o *BillOfLading) SetPodPredictedArrivalLt(v string)`
 
 SetPodPredictedArrivalLt sets PodPredictedArrivalLt field to given value.
 
@@ -514,20 +514,20 @@ HasPodPredictedArrivalLt returns a boolean if a field has been set.
 UnsetPodPredictedArrivalLt ensures that no value is present for PodPredictedArrivalLt, not even an explicit nil
 ### GetPodPredictedDepartureLt
 
-`func (o *BillOfLading) GetPodPredictedDepartureLt() time.Time`
+`func (o *BillOfLading) GetPodPredictedDepartureLt() string`
 
 GetPodPredictedDepartureLt returns the PodPredictedDepartureLt field if non-nil, zero value otherwise.
 
 ### GetPodPredictedDepartureLtOk
 
-`func (o *BillOfLading) GetPodPredictedDepartureLtOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPodPredictedDepartureLtOk() (*string, bool)`
 
 GetPodPredictedDepartureLtOk returns a tuple with the PodPredictedDepartureLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodPredictedDepartureLt
 
-`func (o *BillOfLading) SetPodPredictedDepartureLt(v time.Time)`
+`func (o *BillOfLading) SetPodPredictedDepartureLt(v string)`
 
 SetPodPredictedDepartureLt sets PodPredictedDepartureLt field to given value.
 
@@ -549,20 +549,20 @@ HasPodPredictedDepartureLt returns a boolean if a field has been set.
 UnsetPodPredictedDepartureLt ensures that no value is present for PodPredictedDepartureLt, not even an explicit nil
 ### GetPodScheduledArrivalLt
 
-`func (o *BillOfLading) GetPodScheduledArrivalLt() time.Time`
+`func (o *BillOfLading) GetPodScheduledArrivalLt() string`
 
 GetPodScheduledArrivalLt returns the PodScheduledArrivalLt field if non-nil, zero value otherwise.
 
 ### GetPodScheduledArrivalLtOk
 
-`func (o *BillOfLading) GetPodScheduledArrivalLtOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPodScheduledArrivalLtOk() (*string, bool)`
 
 GetPodScheduledArrivalLtOk returns a tuple with the PodScheduledArrivalLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodScheduledArrivalLt
 
-`func (o *BillOfLading) SetPodScheduledArrivalLt(v time.Time)`
+`func (o *BillOfLading) SetPodScheduledArrivalLt(v string)`
 
 SetPodScheduledArrivalLt sets PodScheduledArrivalLt field to given value.
 
@@ -619,20 +619,20 @@ HasPodScheduledArrivalLtFirstSeen returns a boolean if a field has been set.
 UnsetPodScheduledArrivalLtFirstSeen ensures that no value is present for PodScheduledArrivalLtFirstSeen, not even an explicit nil
 ### GetPodScheduledArrivalLtFromSchedule
 
-`func (o *BillOfLading) GetPodScheduledArrivalLtFromSchedule() time.Time`
+`func (o *BillOfLading) GetPodScheduledArrivalLtFromSchedule() string`
 
 GetPodScheduledArrivalLtFromSchedule returns the PodScheduledArrivalLtFromSchedule field if non-nil, zero value otherwise.
 
 ### GetPodScheduledArrivalLtFromScheduleOk
 
-`func (o *BillOfLading) GetPodScheduledArrivalLtFromScheduleOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPodScheduledArrivalLtFromScheduleOk() (*string, bool)`
 
 GetPodScheduledArrivalLtFromScheduleOk returns a tuple with the PodScheduledArrivalLtFromSchedule field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodScheduledArrivalLtFromSchedule
 
-`func (o *BillOfLading) SetPodScheduledArrivalLtFromSchedule(v time.Time)`
+`func (o *BillOfLading) SetPodScheduledArrivalLtFromSchedule(v string)`
 
 SetPodScheduledArrivalLtFromSchedule sets PodScheduledArrivalLtFromSchedule field to given value.
 
@@ -654,20 +654,20 @@ HasPodScheduledArrivalLtFromSchedule returns a boolean if a field has been set.
 UnsetPodScheduledArrivalLtFromSchedule ensures that no value is present for PodScheduledArrivalLtFromSchedule, not even an explicit nil
 ### GetPodScheduledDepartureLtFromSchedule
 
-`func (o *BillOfLading) GetPodScheduledDepartureLtFromSchedule() time.Time`
+`func (o *BillOfLading) GetPodScheduledDepartureLtFromSchedule() string`
 
 GetPodScheduledDepartureLtFromSchedule returns the PodScheduledDepartureLtFromSchedule field if non-nil, zero value otherwise.
 
 ### GetPodScheduledDepartureLtFromScheduleOk
 
-`func (o *BillOfLading) GetPodScheduledDepartureLtFromScheduleOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPodScheduledDepartureLtFromScheduleOk() (*string, bool)`
 
 GetPodScheduledDepartureLtFromScheduleOk returns a tuple with the PodScheduledDepartureLtFromSchedule field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodScheduledDepartureLtFromSchedule
 
-`func (o *BillOfLading) SetPodScheduledDepartureLtFromSchedule(v time.Time)`
+`func (o *BillOfLading) SetPodScheduledDepartureLtFromSchedule(v string)`
 
 SetPodScheduledDepartureLtFromSchedule sets PodScheduledDepartureLtFromSchedule field to given value.
 
@@ -689,20 +689,20 @@ HasPodScheduledDepartureLtFromSchedule returns a boolean if a field has been set
 UnsetPodScheduledDepartureLtFromSchedule ensures that no value is present for PodScheduledDepartureLtFromSchedule, not even an explicit nil
 ### GetPodScheduledDischargeLt
 
-`func (o *BillOfLading) GetPodScheduledDischargeLt() time.Time`
+`func (o *BillOfLading) GetPodScheduledDischargeLt() string`
 
 GetPodScheduledDischargeLt returns the PodScheduledDischargeLt field if non-nil, zero value otherwise.
 
 ### GetPodScheduledDischargeLtOk
 
-`func (o *BillOfLading) GetPodScheduledDischargeLtOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPodScheduledDischargeLtOk() (*string, bool)`
 
 GetPodScheduledDischargeLtOk returns a tuple with the PodScheduledDischargeLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodScheduledDischargeLt
 
-`func (o *BillOfLading) SetPodScheduledDischargeLt(v time.Time)`
+`func (o *BillOfLading) SetPodScheduledDischargeLt(v string)`
 
 SetPodScheduledDischargeLt sets PodScheduledDischargeLt field to given value.
 
@@ -774,20 +774,20 @@ HasPol returns a boolean if a field has been set.
 
 ### GetPolActualArrivalLtFromAis
 
-`func (o *BillOfLading) GetPolActualArrivalLtFromAis() time.Time`
+`func (o *BillOfLading) GetPolActualArrivalLtFromAis() string`
 
 GetPolActualArrivalLtFromAis returns the PolActualArrivalLtFromAis field if non-nil, zero value otherwise.
 
 ### GetPolActualArrivalLtFromAisOk
 
-`func (o *BillOfLading) GetPolActualArrivalLtFromAisOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPolActualArrivalLtFromAisOk() (*string, bool)`
 
 GetPolActualArrivalLtFromAisOk returns a tuple with the PolActualArrivalLtFromAis field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolActualArrivalLtFromAis
 
-`func (o *BillOfLading) SetPolActualArrivalLtFromAis(v time.Time)`
+`func (o *BillOfLading) SetPolActualArrivalLtFromAis(v string)`
 
 SetPolActualArrivalLtFromAis sets PolActualArrivalLtFromAis field to given value.
 
@@ -809,20 +809,20 @@ HasPolActualArrivalLtFromAis returns a boolean if a field has been set.
 UnsetPolActualArrivalLtFromAis ensures that no value is present for PolActualArrivalLtFromAis, not even an explicit nil
 ### GetPolActualDepartureLt
 
-`func (o *BillOfLading) GetPolActualDepartureLt() time.Time`
+`func (o *BillOfLading) GetPolActualDepartureLt() string`
 
 GetPolActualDepartureLt returns the PolActualDepartureLt field if non-nil, zero value otherwise.
 
 ### GetPolActualDepartureLtOk
 
-`func (o *BillOfLading) GetPolActualDepartureLtOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPolActualDepartureLtOk() (*string, bool)`
 
 GetPolActualDepartureLtOk returns a tuple with the PolActualDepartureLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolActualDepartureLt
 
-`func (o *BillOfLading) SetPolActualDepartureLt(v time.Time)`
+`func (o *BillOfLading) SetPolActualDepartureLt(v string)`
 
 SetPolActualDepartureLt sets PolActualDepartureLt field to given value.
 
@@ -844,20 +844,20 @@ HasPolActualDepartureLt returns a boolean if a field has been set.
 UnsetPolActualDepartureLt ensures that no value is present for PolActualDepartureLt, not even an explicit nil
 ### GetPolActualDepartureLtFromAis
 
-`func (o *BillOfLading) GetPolActualDepartureLtFromAis() time.Time`
+`func (o *BillOfLading) GetPolActualDepartureLtFromAis() string`
 
 GetPolActualDepartureLtFromAis returns the PolActualDepartureLtFromAis field if non-nil, zero value otherwise.
 
 ### GetPolActualDepartureLtFromAisOk
 
-`func (o *BillOfLading) GetPolActualDepartureLtFromAisOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPolActualDepartureLtFromAisOk() (*string, bool)`
 
 GetPolActualDepartureLtFromAisOk returns a tuple with the PolActualDepartureLtFromAis field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolActualDepartureLtFromAis
 
-`func (o *BillOfLading) SetPolActualDepartureLtFromAis(v time.Time)`
+`func (o *BillOfLading) SetPolActualDepartureLtFromAis(v string)`
 
 SetPolActualDepartureLtFromAis sets PolActualDepartureLtFromAis field to given value.
 
@@ -879,20 +879,20 @@ HasPolActualDepartureLtFromAis returns a boolean if a field has been set.
 UnsetPolActualDepartureLtFromAis ensures that no value is present for PolActualDepartureLtFromAis, not even an explicit nil
 ### GetPolActualLoadingLt
 
-`func (o *BillOfLading) GetPolActualLoadingLt() time.Time`
+`func (o *BillOfLading) GetPolActualLoadingLt() string`
 
 GetPolActualLoadingLt returns the PolActualLoadingLt field if non-nil, zero value otherwise.
 
 ### GetPolActualLoadingLtOk
 
-`func (o *BillOfLading) GetPolActualLoadingLtOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPolActualLoadingLtOk() (*string, bool)`
 
 GetPolActualLoadingLtOk returns a tuple with the PolActualLoadingLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolActualLoadingLt
 
-`func (o *BillOfLading) SetPolActualLoadingLt(v time.Time)`
+`func (o *BillOfLading) SetPolActualLoadingLt(v string)`
 
 SetPolActualLoadingLt sets PolActualLoadingLt field to given value.
 
@@ -939,20 +939,20 @@ HasPolName returns a boolean if a field has been set.
 
 ### GetPolPredictedArrivalLt
 
-`func (o *BillOfLading) GetPolPredictedArrivalLt() time.Time`
+`func (o *BillOfLading) GetPolPredictedArrivalLt() string`
 
 GetPolPredictedArrivalLt returns the PolPredictedArrivalLt field if non-nil, zero value otherwise.
 
 ### GetPolPredictedArrivalLtOk
 
-`func (o *BillOfLading) GetPolPredictedArrivalLtOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPolPredictedArrivalLtOk() (*string, bool)`
 
 GetPolPredictedArrivalLtOk returns a tuple with the PolPredictedArrivalLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolPredictedArrivalLt
 
-`func (o *BillOfLading) SetPolPredictedArrivalLt(v time.Time)`
+`func (o *BillOfLading) SetPolPredictedArrivalLt(v string)`
 
 SetPolPredictedArrivalLt sets PolPredictedArrivalLt field to given value.
 
@@ -974,20 +974,20 @@ HasPolPredictedArrivalLt returns a boolean if a field has been set.
 UnsetPolPredictedArrivalLt ensures that no value is present for PolPredictedArrivalLt, not even an explicit nil
 ### GetPolPredictedDepartureLt
 
-`func (o *BillOfLading) GetPolPredictedDepartureLt() time.Time`
+`func (o *BillOfLading) GetPolPredictedDepartureLt() string`
 
 GetPolPredictedDepartureLt returns the PolPredictedDepartureLt field if non-nil, zero value otherwise.
 
 ### GetPolPredictedDepartureLtOk
 
-`func (o *BillOfLading) GetPolPredictedDepartureLtOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPolPredictedDepartureLtOk() (*string, bool)`
 
 GetPolPredictedDepartureLtOk returns a tuple with the PolPredictedDepartureLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolPredictedDepartureLt
 
-`func (o *BillOfLading) SetPolPredictedDepartureLt(v time.Time)`
+`func (o *BillOfLading) SetPolPredictedDepartureLt(v string)`
 
 SetPolPredictedDepartureLt sets PolPredictedDepartureLt field to given value.
 
@@ -1009,20 +1009,20 @@ HasPolPredictedDepartureLt returns a boolean if a field has been set.
 UnsetPolPredictedDepartureLt ensures that no value is present for PolPredictedDepartureLt, not even an explicit nil
 ### GetPolScheduledArrivalLtFromSchedule
 
-`func (o *BillOfLading) GetPolScheduledArrivalLtFromSchedule() time.Time`
+`func (o *BillOfLading) GetPolScheduledArrivalLtFromSchedule() string`
 
 GetPolScheduledArrivalLtFromSchedule returns the PolScheduledArrivalLtFromSchedule field if non-nil, zero value otherwise.
 
 ### GetPolScheduledArrivalLtFromScheduleOk
 
-`func (o *BillOfLading) GetPolScheduledArrivalLtFromScheduleOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPolScheduledArrivalLtFromScheduleOk() (*string, bool)`
 
 GetPolScheduledArrivalLtFromScheduleOk returns a tuple with the PolScheduledArrivalLtFromSchedule field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolScheduledArrivalLtFromSchedule
 
-`func (o *BillOfLading) SetPolScheduledArrivalLtFromSchedule(v time.Time)`
+`func (o *BillOfLading) SetPolScheduledArrivalLtFromSchedule(v string)`
 
 SetPolScheduledArrivalLtFromSchedule sets PolScheduledArrivalLtFromSchedule field to given value.
 
@@ -1044,20 +1044,20 @@ HasPolScheduledArrivalLtFromSchedule returns a boolean if a field has been set.
 UnsetPolScheduledArrivalLtFromSchedule ensures that no value is present for PolScheduledArrivalLtFromSchedule, not even an explicit nil
 ### GetPolScheduledDepartureLt
 
-`func (o *BillOfLading) GetPolScheduledDepartureLt() time.Time`
+`func (o *BillOfLading) GetPolScheduledDepartureLt() string`
 
 GetPolScheduledDepartureLt returns the PolScheduledDepartureLt field if non-nil, zero value otherwise.
 
 ### GetPolScheduledDepartureLtOk
 
-`func (o *BillOfLading) GetPolScheduledDepartureLtOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPolScheduledDepartureLtOk() (*string, bool)`
 
 GetPolScheduledDepartureLtOk returns a tuple with the PolScheduledDepartureLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolScheduledDepartureLt
 
-`func (o *BillOfLading) SetPolScheduledDepartureLt(v time.Time)`
+`func (o *BillOfLading) SetPolScheduledDepartureLt(v string)`
 
 SetPolScheduledDepartureLt sets PolScheduledDepartureLt field to given value.
 
@@ -1114,20 +1114,20 @@ HasPolScheduledDepartureLtFirstSeen returns a boolean if a field has been set.
 UnsetPolScheduledDepartureLtFirstSeen ensures that no value is present for PolScheduledDepartureLtFirstSeen, not even an explicit nil
 ### GetPolScheduledDepartureLtFromSchedule
 
-`func (o *BillOfLading) GetPolScheduledDepartureLtFromSchedule() time.Time`
+`func (o *BillOfLading) GetPolScheduledDepartureLtFromSchedule() string`
 
 GetPolScheduledDepartureLtFromSchedule returns the PolScheduledDepartureLtFromSchedule field if non-nil, zero value otherwise.
 
 ### GetPolScheduledDepartureLtFromScheduleOk
 
-`func (o *BillOfLading) GetPolScheduledDepartureLtFromScheduleOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPolScheduledDepartureLtFromScheduleOk() (*string, bool)`
 
 GetPolScheduledDepartureLtFromScheduleOk returns a tuple with the PolScheduledDepartureLtFromSchedule field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolScheduledDepartureLtFromSchedule
 
-`func (o *BillOfLading) SetPolScheduledDepartureLtFromSchedule(v time.Time)`
+`func (o *BillOfLading) SetPolScheduledDepartureLtFromSchedule(v string)`
 
 SetPolScheduledDepartureLtFromSchedule sets PolScheduledDepartureLtFromSchedule field to given value.
 
@@ -1149,20 +1149,20 @@ HasPolScheduledDepartureLtFromSchedule returns a boolean if a field has been set
 UnsetPolScheduledDepartureLtFromSchedule ensures that no value is present for PolScheduledDepartureLtFromSchedule, not even an explicit nil
 ### GetPolScheduledLoadingLt
 
-`func (o *BillOfLading) GetPolScheduledLoadingLt() time.Time`
+`func (o *BillOfLading) GetPolScheduledLoadingLt() string`
 
 GetPolScheduledLoadingLt returns the PolScheduledLoadingLt field if non-nil, zero value otherwise.
 
 ### GetPolScheduledLoadingLtOk
 
-`func (o *BillOfLading) GetPolScheduledLoadingLtOk() (*time.Time, bool)`
+`func (o *BillOfLading) GetPolScheduledLoadingLtOk() (*string, bool)`
 
 GetPolScheduledLoadingLtOk returns a tuple with the PolScheduledLoadingLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolScheduledLoadingLt
 
-`func (o *BillOfLading) SetPolScheduledLoadingLt(v time.Time)`
+`func (o *BillOfLading) SetPolScheduledLoadingLt(v string)`
 
 SetPolScheduledLoadingLt sets PolScheduledLoadingLt field to given value.
 

--- a/portcast/docs/PortTerminalAddOnExportPlan.md
+++ b/portcast/docs/PortTerminalAddOnExportPlan.md
@@ -12,15 +12,15 @@ Name | Type | Description | Notes
 **FacilityName** | Pointer to **string** | Export port terminal name | [optional] 
 **VesselName** | Pointer to **string** | Vessel name of the vessel associated with the export location. | [optional] 
 **VoyageNo** | Pointer to **string** | Voyage Number associated with the export journey, as reported by the Terminal. | [optional] 
-**ErdStandard** | Pointer to **time.Time** | Earliest Receipt Date (ERD) for a standard container, as reported by the terminal - Local Time. | [optional] 
-**ErdReefer** | Pointer to **time.Time** | Earliest Receipt Date (ERD) for a reefer container, as reported by the terminal - Local Time. | [optional] 
+**ErdStandard** | Pointer to **string** | Earliest Receipt Date (ERD) for a standard container, as reported by the terminal - Local Time. | [optional] 
+**ErdReefer** | Pointer to **string** | Earliest Receipt Date (ERD) for a reefer container, as reported by the terminal - Local Time. | [optional] 
 **GateInDate** | Pointer to **string** | Date a container was received at the terminal through the gate, as reported by the terminal - Local Time. | [optional] 
-**PortCutoffStandard** | Pointer to **time.Time** | Last possible date and time for gating-in standard container at the export terminal, as reported by the Terminal - Local Time. | [optional] 
-**PortCutoffReefer** | Pointer to **time.Time** | Last possible date and time for gating-in reefer container at the export terminal, as reported by the terminal - Local Time. | [optional] 
-**LatestEta** | Pointer to **time.Time** | Latest vessel ETA to the export port, as reported by the terminal - Local Time. | [optional] 
-**ActualArrival** | Pointer to **time.Time** | Actual vessel time of arrival, as reported by the terminal - Local Time. | [optional] 
-**LatestEtd** | Pointer to **time.Time** | Latest vessel ETD from the export port, as reported by the terminal - Local Time. | [optional] 
-**ActualDeparture** | Pointer to **time.Time** | Actual vessel time of departure from the export port, as reported by the terminal - Local Time. | [optional] 
+**PortCutoffStandard** | Pointer to **string** | Last possible date and time for gating-in standard container at the export terminal, as reported by the Terminal - Local Time. | [optional] 
+**PortCutoffReefer** | Pointer to **string** | Last possible date and time for gating-in reefer container at the export terminal, as reported by the terminal - Local Time. | [optional] 
+**LatestEta** | Pointer to **string** | Latest vessel ETA to the export port, as reported by the terminal - Local Time. | [optional] 
+**ActualArrival** | Pointer to **string** | Actual vessel time of arrival, as reported by the terminal - Local Time. | [optional] 
+**LatestEtd** | Pointer to **string** | Latest vessel ETD from the export port, as reported by the terminal - Local Time. | [optional] 
+**ActualDeparture** | Pointer to **string** | Actual vessel time of departure from the export port, as reported by the terminal - Local Time. | [optional] 
 
 ## Methods
 
@@ -243,20 +243,20 @@ HasVoyageNo returns a boolean if a field has been set.
 
 ### GetErdStandard
 
-`func (o *PortTerminalAddOnExportPlan) GetErdStandard() time.Time`
+`func (o *PortTerminalAddOnExportPlan) GetErdStandard() string`
 
 GetErdStandard returns the ErdStandard field if non-nil, zero value otherwise.
 
 ### GetErdStandardOk
 
-`func (o *PortTerminalAddOnExportPlan) GetErdStandardOk() (*time.Time, bool)`
+`func (o *PortTerminalAddOnExportPlan) GetErdStandardOk() (*string, bool)`
 
 GetErdStandardOk returns a tuple with the ErdStandard field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetErdStandard
 
-`func (o *PortTerminalAddOnExportPlan) SetErdStandard(v time.Time)`
+`func (o *PortTerminalAddOnExportPlan) SetErdStandard(v string)`
 
 SetErdStandard sets ErdStandard field to given value.
 
@@ -268,20 +268,20 @@ HasErdStandard returns a boolean if a field has been set.
 
 ### GetErdReefer
 
-`func (o *PortTerminalAddOnExportPlan) GetErdReefer() time.Time`
+`func (o *PortTerminalAddOnExportPlan) GetErdReefer() string`
 
 GetErdReefer returns the ErdReefer field if non-nil, zero value otherwise.
 
 ### GetErdReeferOk
 
-`func (o *PortTerminalAddOnExportPlan) GetErdReeferOk() (*time.Time, bool)`
+`func (o *PortTerminalAddOnExportPlan) GetErdReeferOk() (*string, bool)`
 
 GetErdReeferOk returns a tuple with the ErdReefer field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetErdReefer
 
-`func (o *PortTerminalAddOnExportPlan) SetErdReefer(v time.Time)`
+`func (o *PortTerminalAddOnExportPlan) SetErdReefer(v string)`
 
 SetErdReefer sets ErdReefer field to given value.
 
@@ -318,20 +318,20 @@ HasGateInDate returns a boolean if a field has been set.
 
 ### GetPortCutoffStandard
 
-`func (o *PortTerminalAddOnExportPlan) GetPortCutoffStandard() time.Time`
+`func (o *PortTerminalAddOnExportPlan) GetPortCutoffStandard() string`
 
 GetPortCutoffStandard returns the PortCutoffStandard field if non-nil, zero value otherwise.
 
 ### GetPortCutoffStandardOk
 
-`func (o *PortTerminalAddOnExportPlan) GetPortCutoffStandardOk() (*time.Time, bool)`
+`func (o *PortTerminalAddOnExportPlan) GetPortCutoffStandardOk() (*string, bool)`
 
 GetPortCutoffStandardOk returns a tuple with the PortCutoffStandard field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPortCutoffStandard
 
-`func (o *PortTerminalAddOnExportPlan) SetPortCutoffStandard(v time.Time)`
+`func (o *PortTerminalAddOnExportPlan) SetPortCutoffStandard(v string)`
 
 SetPortCutoffStandard sets PortCutoffStandard field to given value.
 
@@ -343,20 +343,20 @@ HasPortCutoffStandard returns a boolean if a field has been set.
 
 ### GetPortCutoffReefer
 
-`func (o *PortTerminalAddOnExportPlan) GetPortCutoffReefer() time.Time`
+`func (o *PortTerminalAddOnExportPlan) GetPortCutoffReefer() string`
 
 GetPortCutoffReefer returns the PortCutoffReefer field if non-nil, zero value otherwise.
 
 ### GetPortCutoffReeferOk
 
-`func (o *PortTerminalAddOnExportPlan) GetPortCutoffReeferOk() (*time.Time, bool)`
+`func (o *PortTerminalAddOnExportPlan) GetPortCutoffReeferOk() (*string, bool)`
 
 GetPortCutoffReeferOk returns a tuple with the PortCutoffReefer field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPortCutoffReefer
 
-`func (o *PortTerminalAddOnExportPlan) SetPortCutoffReefer(v time.Time)`
+`func (o *PortTerminalAddOnExportPlan) SetPortCutoffReefer(v string)`
 
 SetPortCutoffReefer sets PortCutoffReefer field to given value.
 
@@ -368,20 +368,20 @@ HasPortCutoffReefer returns a boolean if a field has been set.
 
 ### GetLatestEta
 
-`func (o *PortTerminalAddOnExportPlan) GetLatestEta() time.Time`
+`func (o *PortTerminalAddOnExportPlan) GetLatestEta() string`
 
 GetLatestEta returns the LatestEta field if non-nil, zero value otherwise.
 
 ### GetLatestEtaOk
 
-`func (o *PortTerminalAddOnExportPlan) GetLatestEtaOk() (*time.Time, bool)`
+`func (o *PortTerminalAddOnExportPlan) GetLatestEtaOk() (*string, bool)`
 
 GetLatestEtaOk returns a tuple with the LatestEta field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetLatestEta
 
-`func (o *PortTerminalAddOnExportPlan) SetLatestEta(v time.Time)`
+`func (o *PortTerminalAddOnExportPlan) SetLatestEta(v string)`
 
 SetLatestEta sets LatestEta field to given value.
 
@@ -393,20 +393,20 @@ HasLatestEta returns a boolean if a field has been set.
 
 ### GetActualArrival
 
-`func (o *PortTerminalAddOnExportPlan) GetActualArrival() time.Time`
+`func (o *PortTerminalAddOnExportPlan) GetActualArrival() string`
 
 GetActualArrival returns the ActualArrival field if non-nil, zero value otherwise.
 
 ### GetActualArrivalOk
 
-`func (o *PortTerminalAddOnExportPlan) GetActualArrivalOk() (*time.Time, bool)`
+`func (o *PortTerminalAddOnExportPlan) GetActualArrivalOk() (*string, bool)`
 
 GetActualArrivalOk returns a tuple with the ActualArrival field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetActualArrival
 
-`func (o *PortTerminalAddOnExportPlan) SetActualArrival(v time.Time)`
+`func (o *PortTerminalAddOnExportPlan) SetActualArrival(v string)`
 
 SetActualArrival sets ActualArrival field to given value.
 
@@ -418,20 +418,20 @@ HasActualArrival returns a boolean if a field has been set.
 
 ### GetLatestEtd
 
-`func (o *PortTerminalAddOnExportPlan) GetLatestEtd() time.Time`
+`func (o *PortTerminalAddOnExportPlan) GetLatestEtd() string`
 
 GetLatestEtd returns the LatestEtd field if non-nil, zero value otherwise.
 
 ### GetLatestEtdOk
 
-`func (o *PortTerminalAddOnExportPlan) GetLatestEtdOk() (*time.Time, bool)`
+`func (o *PortTerminalAddOnExportPlan) GetLatestEtdOk() (*string, bool)`
 
 GetLatestEtdOk returns a tuple with the LatestEtd field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetLatestEtd
 
-`func (o *PortTerminalAddOnExportPlan) SetLatestEtd(v time.Time)`
+`func (o *PortTerminalAddOnExportPlan) SetLatestEtd(v string)`
 
 SetLatestEtd sets LatestEtd field to given value.
 
@@ -443,20 +443,20 @@ HasLatestEtd returns a boolean if a field has been set.
 
 ### GetActualDeparture
 
-`func (o *PortTerminalAddOnExportPlan) GetActualDeparture() time.Time`
+`func (o *PortTerminalAddOnExportPlan) GetActualDeparture() string`
 
 GetActualDeparture returns the ActualDeparture field if non-nil, zero value otherwise.
 
 ### GetActualDepartureOk
 
-`func (o *PortTerminalAddOnExportPlan) GetActualDepartureOk() (*time.Time, bool)`
+`func (o *PortTerminalAddOnExportPlan) GetActualDepartureOk() (*string, bool)`
 
 GetActualDepartureOk returns a tuple with the ActualDeparture field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetActualDeparture
 
-`func (o *PortTerminalAddOnExportPlan) SetActualDeparture(v time.Time)`
+`func (o *PortTerminalAddOnExportPlan) SetActualDeparture(v string)`
 
 SetActualDeparture sets ActualDeparture field to given value.
 

--- a/portcast/docs/SailingInfoTrackingSailingInfo.md
+++ b/portcast/docs/SailingInfoTrackingSailingInfo.md
@@ -10,30 +10,30 @@ Name | Type | Description | Notes
 **Imo** | Pointer to **NullableString** | Vessel IMO for the Vessel associated with this specific journey leg | [optional] 
 **IsActive** | Pointer to **bool** | Defines if the sailing info is active/latest or not | [optional] [default to true]
 **Pod** | Pointer to **NullableString** | Target Location UNLOCODE for this specific leg of the journey | [optional] 
-**PodActualArrivalLt** | Pointer to **NullableTime** | Actual Arrival Time at the target port location - Local Time | [optional] 
-**PodActualArrivalLtFromAis** | Pointer to **NullableTime** | Actual Arrival Time at the target port location as per AIS Data - Local Time | [optional] 
-**PodActualDepartureLtFromAis** | Pointer to **NullableTime** | Actual Departure Time from the target port location as per AIS Data - Local Time | [optional] 
-**PodActualDischargeLt** | Pointer to **NullableTime** | Actual Time of Discharge at the target port location - Local Time | [optional] 
+**PodActualArrivalLt** | Pointer to **NullableString** | Actual Arrival Time at the target port location - Local Time | [optional] 
+**PodActualArrivalLtFromAis** | Pointer to **NullableString** | Actual Arrival Time at the target port location as per AIS Data - Local Time | [optional] 
+**PodActualDepartureLtFromAis** | Pointer to **NullableString** | Actual Departure Time from the target port location as per AIS Data - Local Time | [optional] 
+**PodActualDischargeLt** | Pointer to **NullableString** | Actual Time of Discharge at the target port location - Local Time | [optional] 
 **PodName** | Pointer to **NullableString** | Target Location Name for this specific leg of the journey | [optional] 
-**PodPredictedArrivalLt** | Pointer to **NullableTime** | Portcast Predicted Time of Arrival at the target port location - Local Time | [optional] 
-**PodPredictedDepartureLt** | Pointer to **NullableTime** | Portcast Predicted Time of Departure from the target port location - Local Time | [optional] 
-**PodScheduledArrivalLt** | Pointer to **NullableTime** | Scheduled Time of Arrival at the target port location - Local Time | [optional] 
-**PodScheduledArrivalLtFromSchedule** | Pointer to **NullableTime** | Scheduled Time of Arrival at the target port location as per Vessel Schedule - Local Time | [optional] 
-**PodScheduledDepartureLtFromSchedule** | Pointer to **NullableTime** | Scheduled Time of Departure from the target port location as per Vessel Schedule - Local Time | [optional] 
-**PodScheduledDischargeLt** | Pointer to **NullableTime** | Scheduled Discharge Time at the target port location - Local Time | [optional] 
+**PodPredictedArrivalLt** | Pointer to **NullableString** | Portcast Predicted Time of Arrival at the target port location - Local Time | [optional] 
+**PodPredictedDepartureLt** | Pointer to **NullableString** | Portcast Predicted Time of Departure from the target port location - Local Time | [optional] 
+**PodScheduledArrivalLt** | Pointer to **NullableString** | Scheduled Time of Arrival at the target port location - Local Time | [optional] 
+**PodScheduledArrivalLtFromSchedule** | Pointer to **NullableString** | Scheduled Time of Arrival at the target port location as per Vessel Schedule - Local Time | [optional] 
+**PodScheduledDepartureLtFromSchedule** | Pointer to **NullableString** | Scheduled Time of Departure from the target port location as per Vessel Schedule - Local Time | [optional] 
+**PodScheduledDischargeLt** | Pointer to **NullableString** | Scheduled Discharge Time at the target port location - Local Time | [optional] 
 **PodTerminalName** | Pointer to **NullableString** | Terminal Name for the Target Port for this specific leg of the journey | [optional] 
 **Pol** | Pointer to **NullableString** | Starting Location UNLOCODE for this specific leg of the journey | [optional] [default to "USHOU"]
-**PolActualArrivalLtFromAis** | Pointer to **NullableTime** | Actual Time of Arrival at the starting port location as per AIS Data - Local Time | [optional] 
-**PolActualDepartureLt** | Pointer to **NullableTime** | Actual Time of Departure from the starting port location - Local Time | [optional] 
-**PolActualDepartureLtFromAis** | Pointer to **NullableTime** | Actual Time of Departure from the starting port location as per AIS Data - Local Time | [optional] 
-**PolActualLoadingLt** | Pointer to **NullableTime** | Actual Loading Time at the starting port location - Local Time | [optional] 
+**PolActualArrivalLtFromAis** | Pointer to **NullableString** | Actual Time of Arrival at the starting port location as per AIS Data - Local Time | [optional] 
+**PolActualDepartureLt** | Pointer to **NullableString** | Actual Time of Departure from the starting port location - Local Time | [optional] 
+**PolActualDepartureLtFromAis** | Pointer to **NullableString** | Actual Time of Departure from the starting port location as per AIS Data - Local Time | [optional] 
+**PolActualLoadingLt** | Pointer to **NullableString** | Actual Loading Time at the starting port location - Local Time | [optional] 
 **PolName** | Pointer to **NullableString** | Starting Location Name for this specific leg of the journey | [optional] [default to "HOUSTON"]
-**PolPredictedArrivalLt** | Pointer to **NullableTime** | Portcast Predicted Time of Arrival at the starting port location - Local Time | [optional] 
-**PolPredictedDepartureLt** | Pointer to **NullableTime** | Portcast Predicted Time of Departure from the starting port location - Local Time | [optional] 
-**PolScheduledArrivalLtFromSchedule** | Pointer to **NullableTime** | Scheduled Time of Arrival at the starting port location as per Vessel Schedule- Local Time | [optional] 
-**PolScheduledDepartureLt** | Pointer to **NullableTime** | Scheduled Time of Departure from the starting port location - Local Time | [optional] 
-**PolScheduledDepartureLtFromSchedule** | Pointer to **NullableTime** | Scheduled Time of Departure from the starting port location as per Vessel Schedule - Local Time | [optional] 
-**PolScheduledLoadingLt** | Pointer to **NullableTime** | Scheduled Loading Time at the starting port location - Local Time | [optional] 
+**PolPredictedArrivalLt** | Pointer to **NullableString** | Portcast Predicted Time of Arrival at the starting port location - Local Time | [optional] 
+**PolPredictedDepartureLt** | Pointer to **NullableString** | Portcast Predicted Time of Departure from the starting port location - Local Time | [optional] 
+**PolScheduledArrivalLtFromSchedule** | Pointer to **NullableString** | Scheduled Time of Arrival at the starting port location as per Vessel Schedule- Local Time | [optional] 
+**PolScheduledDepartureLt** | Pointer to **NullableString** | Scheduled Time of Departure from the starting port location - Local Time | [optional] 
+**PolScheduledDepartureLtFromSchedule** | Pointer to **NullableString** | Scheduled Time of Departure from the starting port location as per Vessel Schedule - Local Time | [optional] 
+**PolScheduledLoadingLt** | Pointer to **NullableString** | Scheduled Loading Time at the starting port location - Local Time | [optional] 
 **PolTerminalName** | Pointer to **NullableString** | Terminal Name for the Port of Loading (POL) | [optional] 
 **Updated** | Pointer to **NullableTime** | Sailing Info Updated Date | [optional] 
 **VesselFlag** | Pointer to **NullableString** | Vessel Name for the Vessel Flag for the vessel associated with this specific journey leg | [optional] 
@@ -242,20 +242,20 @@ HasPod returns a boolean if a field has been set.
 UnsetPod ensures that no value is present for Pod, not even an explicit nil
 ### GetPodActualArrivalLt
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodActualArrivalLt() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPodActualArrivalLt() string`
 
 GetPodActualArrivalLt returns the PodActualArrivalLt field if non-nil, zero value otherwise.
 
 ### GetPodActualArrivalLtOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodActualArrivalLtOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPodActualArrivalLtOk() (*string, bool)`
 
 GetPodActualArrivalLtOk returns a tuple with the PodActualArrivalLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodActualArrivalLt
 
-`func (o *SailingInfoTrackingSailingInfo) SetPodActualArrivalLt(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPodActualArrivalLt(v string)`
 
 SetPodActualArrivalLt sets PodActualArrivalLt field to given value.
 
@@ -277,20 +277,20 @@ HasPodActualArrivalLt returns a boolean if a field has been set.
 UnsetPodActualArrivalLt ensures that no value is present for PodActualArrivalLt, not even an explicit nil
 ### GetPodActualArrivalLtFromAis
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodActualArrivalLtFromAis() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPodActualArrivalLtFromAis() string`
 
 GetPodActualArrivalLtFromAis returns the PodActualArrivalLtFromAis field if non-nil, zero value otherwise.
 
 ### GetPodActualArrivalLtFromAisOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodActualArrivalLtFromAisOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPodActualArrivalLtFromAisOk() (*string, bool)`
 
 GetPodActualArrivalLtFromAisOk returns a tuple with the PodActualArrivalLtFromAis field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodActualArrivalLtFromAis
 
-`func (o *SailingInfoTrackingSailingInfo) SetPodActualArrivalLtFromAis(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPodActualArrivalLtFromAis(v string)`
 
 SetPodActualArrivalLtFromAis sets PodActualArrivalLtFromAis field to given value.
 
@@ -312,20 +312,20 @@ HasPodActualArrivalLtFromAis returns a boolean if a field has been set.
 UnsetPodActualArrivalLtFromAis ensures that no value is present for PodActualArrivalLtFromAis, not even an explicit nil
 ### GetPodActualDepartureLtFromAis
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodActualDepartureLtFromAis() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPodActualDepartureLtFromAis() string`
 
 GetPodActualDepartureLtFromAis returns the PodActualDepartureLtFromAis field if non-nil, zero value otherwise.
 
 ### GetPodActualDepartureLtFromAisOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodActualDepartureLtFromAisOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPodActualDepartureLtFromAisOk() (*string, bool)`
 
 GetPodActualDepartureLtFromAisOk returns a tuple with the PodActualDepartureLtFromAis field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodActualDepartureLtFromAis
 
-`func (o *SailingInfoTrackingSailingInfo) SetPodActualDepartureLtFromAis(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPodActualDepartureLtFromAis(v string)`
 
 SetPodActualDepartureLtFromAis sets PodActualDepartureLtFromAis field to given value.
 
@@ -347,20 +347,20 @@ HasPodActualDepartureLtFromAis returns a boolean if a field has been set.
 UnsetPodActualDepartureLtFromAis ensures that no value is present for PodActualDepartureLtFromAis, not even an explicit nil
 ### GetPodActualDischargeLt
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodActualDischargeLt() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPodActualDischargeLt() string`
 
 GetPodActualDischargeLt returns the PodActualDischargeLt field if non-nil, zero value otherwise.
 
 ### GetPodActualDischargeLtOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodActualDischargeLtOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPodActualDischargeLtOk() (*string, bool)`
 
 GetPodActualDischargeLtOk returns a tuple with the PodActualDischargeLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodActualDischargeLt
 
-`func (o *SailingInfoTrackingSailingInfo) SetPodActualDischargeLt(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPodActualDischargeLt(v string)`
 
 SetPodActualDischargeLt sets PodActualDischargeLt field to given value.
 
@@ -417,20 +417,20 @@ HasPodName returns a boolean if a field has been set.
 UnsetPodName ensures that no value is present for PodName, not even an explicit nil
 ### GetPodPredictedArrivalLt
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodPredictedArrivalLt() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPodPredictedArrivalLt() string`
 
 GetPodPredictedArrivalLt returns the PodPredictedArrivalLt field if non-nil, zero value otherwise.
 
 ### GetPodPredictedArrivalLtOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodPredictedArrivalLtOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPodPredictedArrivalLtOk() (*string, bool)`
 
 GetPodPredictedArrivalLtOk returns a tuple with the PodPredictedArrivalLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodPredictedArrivalLt
 
-`func (o *SailingInfoTrackingSailingInfo) SetPodPredictedArrivalLt(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPodPredictedArrivalLt(v string)`
 
 SetPodPredictedArrivalLt sets PodPredictedArrivalLt field to given value.
 
@@ -452,20 +452,20 @@ HasPodPredictedArrivalLt returns a boolean if a field has been set.
 UnsetPodPredictedArrivalLt ensures that no value is present for PodPredictedArrivalLt, not even an explicit nil
 ### GetPodPredictedDepartureLt
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodPredictedDepartureLt() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPodPredictedDepartureLt() string`
 
 GetPodPredictedDepartureLt returns the PodPredictedDepartureLt field if non-nil, zero value otherwise.
 
 ### GetPodPredictedDepartureLtOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodPredictedDepartureLtOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPodPredictedDepartureLtOk() (*string, bool)`
 
 GetPodPredictedDepartureLtOk returns a tuple with the PodPredictedDepartureLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodPredictedDepartureLt
 
-`func (o *SailingInfoTrackingSailingInfo) SetPodPredictedDepartureLt(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPodPredictedDepartureLt(v string)`
 
 SetPodPredictedDepartureLt sets PodPredictedDepartureLt field to given value.
 
@@ -487,20 +487,20 @@ HasPodPredictedDepartureLt returns a boolean if a field has been set.
 UnsetPodPredictedDepartureLt ensures that no value is present for PodPredictedDepartureLt, not even an explicit nil
 ### GetPodScheduledArrivalLt
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodScheduledArrivalLt() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPodScheduledArrivalLt() string`
 
 GetPodScheduledArrivalLt returns the PodScheduledArrivalLt field if non-nil, zero value otherwise.
 
 ### GetPodScheduledArrivalLtOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodScheduledArrivalLtOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPodScheduledArrivalLtOk() (*string, bool)`
 
 GetPodScheduledArrivalLtOk returns a tuple with the PodScheduledArrivalLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodScheduledArrivalLt
 
-`func (o *SailingInfoTrackingSailingInfo) SetPodScheduledArrivalLt(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPodScheduledArrivalLt(v string)`
 
 SetPodScheduledArrivalLt sets PodScheduledArrivalLt field to given value.
 
@@ -522,20 +522,20 @@ HasPodScheduledArrivalLt returns a boolean if a field has been set.
 UnsetPodScheduledArrivalLt ensures that no value is present for PodScheduledArrivalLt, not even an explicit nil
 ### GetPodScheduledArrivalLtFromSchedule
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodScheduledArrivalLtFromSchedule() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPodScheduledArrivalLtFromSchedule() string`
 
 GetPodScheduledArrivalLtFromSchedule returns the PodScheduledArrivalLtFromSchedule field if non-nil, zero value otherwise.
 
 ### GetPodScheduledArrivalLtFromScheduleOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodScheduledArrivalLtFromScheduleOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPodScheduledArrivalLtFromScheduleOk() (*string, bool)`
 
 GetPodScheduledArrivalLtFromScheduleOk returns a tuple with the PodScheduledArrivalLtFromSchedule field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodScheduledArrivalLtFromSchedule
 
-`func (o *SailingInfoTrackingSailingInfo) SetPodScheduledArrivalLtFromSchedule(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPodScheduledArrivalLtFromSchedule(v string)`
 
 SetPodScheduledArrivalLtFromSchedule sets PodScheduledArrivalLtFromSchedule field to given value.
 
@@ -557,20 +557,20 @@ HasPodScheduledArrivalLtFromSchedule returns a boolean if a field has been set.
 UnsetPodScheduledArrivalLtFromSchedule ensures that no value is present for PodScheduledArrivalLtFromSchedule, not even an explicit nil
 ### GetPodScheduledDepartureLtFromSchedule
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodScheduledDepartureLtFromSchedule() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPodScheduledDepartureLtFromSchedule() string`
 
 GetPodScheduledDepartureLtFromSchedule returns the PodScheduledDepartureLtFromSchedule field if non-nil, zero value otherwise.
 
 ### GetPodScheduledDepartureLtFromScheduleOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodScheduledDepartureLtFromScheduleOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPodScheduledDepartureLtFromScheduleOk() (*string, bool)`
 
 GetPodScheduledDepartureLtFromScheduleOk returns a tuple with the PodScheduledDepartureLtFromSchedule field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodScheduledDepartureLtFromSchedule
 
-`func (o *SailingInfoTrackingSailingInfo) SetPodScheduledDepartureLtFromSchedule(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPodScheduledDepartureLtFromSchedule(v string)`
 
 SetPodScheduledDepartureLtFromSchedule sets PodScheduledDepartureLtFromSchedule field to given value.
 
@@ -592,20 +592,20 @@ HasPodScheduledDepartureLtFromSchedule returns a boolean if a field has been set
 UnsetPodScheduledDepartureLtFromSchedule ensures that no value is present for PodScheduledDepartureLtFromSchedule, not even an explicit nil
 ### GetPodScheduledDischargeLt
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodScheduledDischargeLt() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPodScheduledDischargeLt() string`
 
 GetPodScheduledDischargeLt returns the PodScheduledDischargeLt field if non-nil, zero value otherwise.
 
 ### GetPodScheduledDischargeLtOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPodScheduledDischargeLtOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPodScheduledDischargeLtOk() (*string, bool)`
 
 GetPodScheduledDischargeLtOk returns a tuple with the PodScheduledDischargeLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPodScheduledDischargeLt
 
-`func (o *SailingInfoTrackingSailingInfo) SetPodScheduledDischargeLt(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPodScheduledDischargeLt(v string)`
 
 SetPodScheduledDischargeLt sets PodScheduledDischargeLt field to given value.
 
@@ -697,20 +697,20 @@ HasPol returns a boolean if a field has been set.
 UnsetPol ensures that no value is present for Pol, not even an explicit nil
 ### GetPolActualArrivalLtFromAis
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolActualArrivalLtFromAis() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPolActualArrivalLtFromAis() string`
 
 GetPolActualArrivalLtFromAis returns the PolActualArrivalLtFromAis field if non-nil, zero value otherwise.
 
 ### GetPolActualArrivalLtFromAisOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolActualArrivalLtFromAisOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPolActualArrivalLtFromAisOk() (*string, bool)`
 
 GetPolActualArrivalLtFromAisOk returns a tuple with the PolActualArrivalLtFromAis field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolActualArrivalLtFromAis
 
-`func (o *SailingInfoTrackingSailingInfo) SetPolActualArrivalLtFromAis(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPolActualArrivalLtFromAis(v string)`
 
 SetPolActualArrivalLtFromAis sets PolActualArrivalLtFromAis field to given value.
 
@@ -732,20 +732,20 @@ HasPolActualArrivalLtFromAis returns a boolean if a field has been set.
 UnsetPolActualArrivalLtFromAis ensures that no value is present for PolActualArrivalLtFromAis, not even an explicit nil
 ### GetPolActualDepartureLt
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolActualDepartureLt() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPolActualDepartureLt() string`
 
 GetPolActualDepartureLt returns the PolActualDepartureLt field if non-nil, zero value otherwise.
 
 ### GetPolActualDepartureLtOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolActualDepartureLtOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPolActualDepartureLtOk() (*string, bool)`
 
 GetPolActualDepartureLtOk returns a tuple with the PolActualDepartureLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolActualDepartureLt
 
-`func (o *SailingInfoTrackingSailingInfo) SetPolActualDepartureLt(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPolActualDepartureLt(v string)`
 
 SetPolActualDepartureLt sets PolActualDepartureLt field to given value.
 
@@ -767,20 +767,20 @@ HasPolActualDepartureLt returns a boolean if a field has been set.
 UnsetPolActualDepartureLt ensures that no value is present for PolActualDepartureLt, not even an explicit nil
 ### GetPolActualDepartureLtFromAis
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolActualDepartureLtFromAis() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPolActualDepartureLtFromAis() string`
 
 GetPolActualDepartureLtFromAis returns the PolActualDepartureLtFromAis field if non-nil, zero value otherwise.
 
 ### GetPolActualDepartureLtFromAisOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolActualDepartureLtFromAisOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPolActualDepartureLtFromAisOk() (*string, bool)`
 
 GetPolActualDepartureLtFromAisOk returns a tuple with the PolActualDepartureLtFromAis field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolActualDepartureLtFromAis
 
-`func (o *SailingInfoTrackingSailingInfo) SetPolActualDepartureLtFromAis(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPolActualDepartureLtFromAis(v string)`
 
 SetPolActualDepartureLtFromAis sets PolActualDepartureLtFromAis field to given value.
 
@@ -802,20 +802,20 @@ HasPolActualDepartureLtFromAis returns a boolean if a field has been set.
 UnsetPolActualDepartureLtFromAis ensures that no value is present for PolActualDepartureLtFromAis, not even an explicit nil
 ### GetPolActualLoadingLt
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolActualLoadingLt() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPolActualLoadingLt() string`
 
 GetPolActualLoadingLt returns the PolActualLoadingLt field if non-nil, zero value otherwise.
 
 ### GetPolActualLoadingLtOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolActualLoadingLtOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPolActualLoadingLtOk() (*string, bool)`
 
 GetPolActualLoadingLtOk returns a tuple with the PolActualLoadingLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolActualLoadingLt
 
-`func (o *SailingInfoTrackingSailingInfo) SetPolActualLoadingLt(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPolActualLoadingLt(v string)`
 
 SetPolActualLoadingLt sets PolActualLoadingLt field to given value.
 
@@ -872,20 +872,20 @@ HasPolName returns a boolean if a field has been set.
 UnsetPolName ensures that no value is present for PolName, not even an explicit nil
 ### GetPolPredictedArrivalLt
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolPredictedArrivalLt() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPolPredictedArrivalLt() string`
 
 GetPolPredictedArrivalLt returns the PolPredictedArrivalLt field if non-nil, zero value otherwise.
 
 ### GetPolPredictedArrivalLtOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolPredictedArrivalLtOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPolPredictedArrivalLtOk() (*string, bool)`
 
 GetPolPredictedArrivalLtOk returns a tuple with the PolPredictedArrivalLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolPredictedArrivalLt
 
-`func (o *SailingInfoTrackingSailingInfo) SetPolPredictedArrivalLt(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPolPredictedArrivalLt(v string)`
 
 SetPolPredictedArrivalLt sets PolPredictedArrivalLt field to given value.
 
@@ -907,20 +907,20 @@ HasPolPredictedArrivalLt returns a boolean if a field has been set.
 UnsetPolPredictedArrivalLt ensures that no value is present for PolPredictedArrivalLt, not even an explicit nil
 ### GetPolPredictedDepartureLt
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolPredictedDepartureLt() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPolPredictedDepartureLt() string`
 
 GetPolPredictedDepartureLt returns the PolPredictedDepartureLt field if non-nil, zero value otherwise.
 
 ### GetPolPredictedDepartureLtOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolPredictedDepartureLtOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPolPredictedDepartureLtOk() (*string, bool)`
 
 GetPolPredictedDepartureLtOk returns a tuple with the PolPredictedDepartureLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolPredictedDepartureLt
 
-`func (o *SailingInfoTrackingSailingInfo) SetPolPredictedDepartureLt(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPolPredictedDepartureLt(v string)`
 
 SetPolPredictedDepartureLt sets PolPredictedDepartureLt field to given value.
 
@@ -942,20 +942,20 @@ HasPolPredictedDepartureLt returns a boolean if a field has been set.
 UnsetPolPredictedDepartureLt ensures that no value is present for PolPredictedDepartureLt, not even an explicit nil
 ### GetPolScheduledArrivalLtFromSchedule
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolScheduledArrivalLtFromSchedule() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPolScheduledArrivalLtFromSchedule() string`
 
 GetPolScheduledArrivalLtFromSchedule returns the PolScheduledArrivalLtFromSchedule field if non-nil, zero value otherwise.
 
 ### GetPolScheduledArrivalLtFromScheduleOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolScheduledArrivalLtFromScheduleOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPolScheduledArrivalLtFromScheduleOk() (*string, bool)`
 
 GetPolScheduledArrivalLtFromScheduleOk returns a tuple with the PolScheduledArrivalLtFromSchedule field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolScheduledArrivalLtFromSchedule
 
-`func (o *SailingInfoTrackingSailingInfo) SetPolScheduledArrivalLtFromSchedule(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPolScheduledArrivalLtFromSchedule(v string)`
 
 SetPolScheduledArrivalLtFromSchedule sets PolScheduledArrivalLtFromSchedule field to given value.
 
@@ -977,20 +977,20 @@ HasPolScheduledArrivalLtFromSchedule returns a boolean if a field has been set.
 UnsetPolScheduledArrivalLtFromSchedule ensures that no value is present for PolScheduledArrivalLtFromSchedule, not even an explicit nil
 ### GetPolScheduledDepartureLt
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolScheduledDepartureLt() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPolScheduledDepartureLt() string`
 
 GetPolScheduledDepartureLt returns the PolScheduledDepartureLt field if non-nil, zero value otherwise.
 
 ### GetPolScheduledDepartureLtOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolScheduledDepartureLtOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPolScheduledDepartureLtOk() (*string, bool)`
 
 GetPolScheduledDepartureLtOk returns a tuple with the PolScheduledDepartureLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolScheduledDepartureLt
 
-`func (o *SailingInfoTrackingSailingInfo) SetPolScheduledDepartureLt(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPolScheduledDepartureLt(v string)`
 
 SetPolScheduledDepartureLt sets PolScheduledDepartureLt field to given value.
 
@@ -1012,20 +1012,20 @@ HasPolScheduledDepartureLt returns a boolean if a field has been set.
 UnsetPolScheduledDepartureLt ensures that no value is present for PolScheduledDepartureLt, not even an explicit nil
 ### GetPolScheduledDepartureLtFromSchedule
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolScheduledDepartureLtFromSchedule() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPolScheduledDepartureLtFromSchedule() string`
 
 GetPolScheduledDepartureLtFromSchedule returns the PolScheduledDepartureLtFromSchedule field if non-nil, zero value otherwise.
 
 ### GetPolScheduledDepartureLtFromScheduleOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolScheduledDepartureLtFromScheduleOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPolScheduledDepartureLtFromScheduleOk() (*string, bool)`
 
 GetPolScheduledDepartureLtFromScheduleOk returns a tuple with the PolScheduledDepartureLtFromSchedule field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolScheduledDepartureLtFromSchedule
 
-`func (o *SailingInfoTrackingSailingInfo) SetPolScheduledDepartureLtFromSchedule(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPolScheduledDepartureLtFromSchedule(v string)`
 
 SetPolScheduledDepartureLtFromSchedule sets PolScheduledDepartureLtFromSchedule field to given value.
 
@@ -1047,20 +1047,20 @@ HasPolScheduledDepartureLtFromSchedule returns a boolean if a field has been set
 UnsetPolScheduledDepartureLtFromSchedule ensures that no value is present for PolScheduledDepartureLtFromSchedule, not even an explicit nil
 ### GetPolScheduledLoadingLt
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolScheduledLoadingLt() time.Time`
+`func (o *SailingInfoTrackingSailingInfo) GetPolScheduledLoadingLt() string`
 
 GetPolScheduledLoadingLt returns the PolScheduledLoadingLt field if non-nil, zero value otherwise.
 
 ### GetPolScheduledLoadingLtOk
 
-`func (o *SailingInfoTrackingSailingInfo) GetPolScheduledLoadingLtOk() (*time.Time, bool)`
+`func (o *SailingInfoTrackingSailingInfo) GetPolScheduledLoadingLtOk() (*string, bool)`
 
 GetPolScheduledLoadingLtOk returns a tuple with the PolScheduledLoadingLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPolScheduledLoadingLt
 
-`func (o *SailingInfoTrackingSailingInfo) SetPolScheduledLoadingLt(v time.Time)`
+`func (o *SailingInfoTrackingSailingInfo) SetPolScheduledLoadingLt(v string)`
 
 SetPolScheduledLoadingLt sets PolScheduledLoadingLt field to given value.
 

--- a/portcast/docs/VoyageDetails.md
+++ b/portcast/docs/VoyageDetails.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ActiveScac** | Pointer to **NullableString** | Vessel Schedule Provider SCAC | [optional] 
-**ActualArrivalLt** | Pointer to **NullableTime** | Actual Time of Arrival - Local Time | [optional] 
+**ActualArrivalLt** | Pointer to **NullableString** | Actual Time of Arrival - Local Time | [optional] 
 **ActualArrivalUtc** | Pointer to **NullableTime** | Actual Time of Arrival - UTC Adjusted Time | [optional] 
-**ActualDepartureLt** | Pointer to **NullableTime** | Actual Time of Departure - Local Time | [optional] 
+**ActualDepartureLt** | Pointer to **NullableString** | Actual Time of Departure - Local Time | [optional] 
 **ActualDepartureUtc** | Pointer to **NullableTime** | Actual Time of Departure - UTC Adjusted Time | [optional] 
 **DelayReasons** | Pointer to **[]string** |  | [optional] 
 **Id** | Pointer to **string** | Unique Identifier for the Voyage Detail | [optional] 
@@ -16,14 +16,14 @@ Name | Type | Description | Notes
 **Lon** | Pointer to **float32** | Longitude of the Port Location | [optional] 
 **PortCode** | Pointer to **string** | Port Location UNLOCODE | [optional] 
 **PortName** | Pointer to **string** | Port Location Name | [optional] 
-**PredictedArrivalLt** | Pointer to **NullableTime** | Portcast Predicted Arrival Time - Local Time | [optional] 
+**PredictedArrivalLt** | Pointer to **NullableString** | Portcast Predicted Arrival Time - Local Time | [optional] 
 **PredictedArrivalUtc** | Pointer to **NullableTime** | Portcast Predicted Arrival Time - UTC Adjusted | [optional] 
-**PredictedDepartureLt** | Pointer to **NullableTime** | Portcast Predicted Departure Time - Local Time | [optional] 
+**PredictedDepartureLt** | Pointer to **NullableString** | Portcast Predicted Departure Time - Local Time | [optional] 
 **PredictedDepartureUtc** | Pointer to **NullableTime** | Portcast Predicted Departure Time - UTC Adjusted Time | [optional] 
 **PredictionTimeUtc** | Pointer to **NullableTime** | Prediction Generation Timestamp | [optional] 
-**ScheduledArrivalLt** | Pointer to **NullableTime** | Vessel Scheduled Arrival Time - Local Time | [optional] 
+**ScheduledArrivalLt** | Pointer to **NullableString** | Vessel Scheduled Arrival Time - Local Time | [optional] 
 **ScheduledArrivalUtc** | Pointer to **NullableTime** | Vessel Scheduled Arrival Time - UTC Adjusted Time | [optional] 
-**ScheduledDepartureLt** | Pointer to **NullableTime** | Vessel Scheduled Departure Time - Local Time | [optional] 
+**ScheduledDepartureLt** | Pointer to **NullableString** | Vessel Scheduled Departure Time - Local Time | [optional] 
 **ScheduledDepartureUtc** | Pointer to **NullableTime** | Vessel Scheduled Departure Time - Departure Time | [optional] 
 **Timezone** | Pointer to **NullableString** | Timezone of the Port Location | [optional] 
 **VoyageNoList** | Pointer to **[]string** | Voyage Numbers at the Port Location (Comes from schedule for that leg ; first one is import voyage number, second one is export voyage no) | [optional] 
@@ -84,20 +84,20 @@ HasActiveScac returns a boolean if a field has been set.
 UnsetActiveScac ensures that no value is present for ActiveScac, not even an explicit nil
 ### GetActualArrivalLt
 
-`func (o *VoyageDetails) GetActualArrivalLt() time.Time`
+`func (o *VoyageDetails) GetActualArrivalLt() string`
 
 GetActualArrivalLt returns the ActualArrivalLt field if non-nil, zero value otherwise.
 
 ### GetActualArrivalLtOk
 
-`func (o *VoyageDetails) GetActualArrivalLtOk() (*time.Time, bool)`
+`func (o *VoyageDetails) GetActualArrivalLtOk() (*string, bool)`
 
 GetActualArrivalLtOk returns a tuple with the ActualArrivalLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetActualArrivalLt
 
-`func (o *VoyageDetails) SetActualArrivalLt(v time.Time)`
+`func (o *VoyageDetails) SetActualArrivalLt(v string)`
 
 SetActualArrivalLt sets ActualArrivalLt field to given value.
 
@@ -154,20 +154,20 @@ HasActualArrivalUtc returns a boolean if a field has been set.
 UnsetActualArrivalUtc ensures that no value is present for ActualArrivalUtc, not even an explicit nil
 ### GetActualDepartureLt
 
-`func (o *VoyageDetails) GetActualDepartureLt() time.Time`
+`func (o *VoyageDetails) GetActualDepartureLt() string`
 
 GetActualDepartureLt returns the ActualDepartureLt field if non-nil, zero value otherwise.
 
 ### GetActualDepartureLtOk
 
-`func (o *VoyageDetails) GetActualDepartureLtOk() (*time.Time, bool)`
+`func (o *VoyageDetails) GetActualDepartureLtOk() (*string, bool)`
 
 GetActualDepartureLtOk returns a tuple with the ActualDepartureLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetActualDepartureLt
 
-`func (o *VoyageDetails) SetActualDepartureLt(v time.Time)`
+`func (o *VoyageDetails) SetActualDepartureLt(v string)`
 
 SetActualDepartureLt sets ActualDepartureLt field to given value.
 
@@ -399,20 +399,20 @@ HasPortName returns a boolean if a field has been set.
 
 ### GetPredictedArrivalLt
 
-`func (o *VoyageDetails) GetPredictedArrivalLt() time.Time`
+`func (o *VoyageDetails) GetPredictedArrivalLt() string`
 
 GetPredictedArrivalLt returns the PredictedArrivalLt field if non-nil, zero value otherwise.
 
 ### GetPredictedArrivalLtOk
 
-`func (o *VoyageDetails) GetPredictedArrivalLtOk() (*time.Time, bool)`
+`func (o *VoyageDetails) GetPredictedArrivalLtOk() (*string, bool)`
 
 GetPredictedArrivalLtOk returns a tuple with the PredictedArrivalLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPredictedArrivalLt
 
-`func (o *VoyageDetails) SetPredictedArrivalLt(v time.Time)`
+`func (o *VoyageDetails) SetPredictedArrivalLt(v string)`
 
 SetPredictedArrivalLt sets PredictedArrivalLt field to given value.
 
@@ -469,20 +469,20 @@ HasPredictedArrivalUtc returns a boolean if a field has been set.
 UnsetPredictedArrivalUtc ensures that no value is present for PredictedArrivalUtc, not even an explicit nil
 ### GetPredictedDepartureLt
 
-`func (o *VoyageDetails) GetPredictedDepartureLt() time.Time`
+`func (o *VoyageDetails) GetPredictedDepartureLt() string`
 
 GetPredictedDepartureLt returns the PredictedDepartureLt field if non-nil, zero value otherwise.
 
 ### GetPredictedDepartureLtOk
 
-`func (o *VoyageDetails) GetPredictedDepartureLtOk() (*time.Time, bool)`
+`func (o *VoyageDetails) GetPredictedDepartureLtOk() (*string, bool)`
 
 GetPredictedDepartureLtOk returns a tuple with the PredictedDepartureLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPredictedDepartureLt
 
-`func (o *VoyageDetails) SetPredictedDepartureLt(v time.Time)`
+`func (o *VoyageDetails) SetPredictedDepartureLt(v string)`
 
 SetPredictedDepartureLt sets PredictedDepartureLt field to given value.
 
@@ -574,20 +574,20 @@ HasPredictionTimeUtc returns a boolean if a field has been set.
 UnsetPredictionTimeUtc ensures that no value is present for PredictionTimeUtc, not even an explicit nil
 ### GetScheduledArrivalLt
 
-`func (o *VoyageDetails) GetScheduledArrivalLt() time.Time`
+`func (o *VoyageDetails) GetScheduledArrivalLt() string`
 
 GetScheduledArrivalLt returns the ScheduledArrivalLt field if non-nil, zero value otherwise.
 
 ### GetScheduledArrivalLtOk
 
-`func (o *VoyageDetails) GetScheduledArrivalLtOk() (*time.Time, bool)`
+`func (o *VoyageDetails) GetScheduledArrivalLtOk() (*string, bool)`
 
 GetScheduledArrivalLtOk returns a tuple with the ScheduledArrivalLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetScheduledArrivalLt
 
-`func (o *VoyageDetails) SetScheduledArrivalLt(v time.Time)`
+`func (o *VoyageDetails) SetScheduledArrivalLt(v string)`
 
 SetScheduledArrivalLt sets ScheduledArrivalLt field to given value.
 
@@ -644,20 +644,20 @@ HasScheduledArrivalUtc returns a boolean if a field has been set.
 UnsetScheduledArrivalUtc ensures that no value is present for ScheduledArrivalUtc, not even an explicit nil
 ### GetScheduledDepartureLt
 
-`func (o *VoyageDetails) GetScheduledDepartureLt() time.Time`
+`func (o *VoyageDetails) GetScheduledDepartureLt() string`
 
 GetScheduledDepartureLt returns the ScheduledDepartureLt field if non-nil, zero value otherwise.
 
 ### GetScheduledDepartureLtOk
 
-`func (o *VoyageDetails) GetScheduledDepartureLtOk() (*time.Time, bool)`
+`func (o *VoyageDetails) GetScheduledDepartureLtOk() (*string, bool)`
 
 GetScheduledDepartureLtOk returns a tuple with the ScheduledDepartureLt field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetScheduledDepartureLt
 
-`func (o *VoyageDetails) SetScheduledDepartureLt(v time.Time)`
+`func (o *VoyageDetails) SetScheduledDepartureLt(v string)`
 
 SetScheduledDepartureLt sets ScheduledDepartureLt field to given value.
 

--- a/portcast/model_bill_of_lading.go
+++ b/portcast/model_bill_of_lading.go
@@ -42,57 +42,57 @@ type BillOfLading struct {
 	// UNLOCODE for the Port of Discharge
 	Pod *string `json:"pod,omitempty"`
 	// Actual Time of Arrival for the Final Vessel at the Port of Discharge (POD) - Local Time
-	PodActualArrivalLt NullableTime `json:"pod_actual_arrival_lt,omitempty"`
+	PodActualArrivalLt NullableString `json:"pod_actual_arrival_lt,omitempty"`
 	// Actual Time of Arrival for the Final Vessel at the Port of Discharge (POD) as per AIS Data- Local Time
-	PodActualArrivalLtFromAis NullableTime `json:"pod_actual_arrival_lt_from_ais,omitempty"`
+	PodActualArrivalLtFromAis NullableString `json:"pod_actual_arrival_lt_from_ais,omitempty"`
 	// Actual Time of Departure for the Final Vessel from the Port of Discharge (POD) as per AIS Data - Local Time
-	PodActualDepartureLtFromAis NullableTime `json:"pod_actual_departure_lt_from_ais,omitempty"`
+	PodActualDepartureLtFromAis NullableString `json:"pod_actual_departure_lt_from_ais,omitempty"`
 	// Actual Container Discharge Time from Final Vessel at the Port of Discharge (POD) - Local Time
-	PodActualDischargeLt NullableTime `json:"pod_actual_discharge_lt,omitempty"`
+	PodActualDischargeLt NullableString `json:"pod_actual_discharge_lt,omitempty"`
 	// Port of Discharge Name
 	PodName *string `json:"pod_name,omitempty"`
 	// Portcast Predicted Time of Arrival for the Final Vessel at the Port of Discharge (POD) - Local Time [Most Reliable Source of ETA]
-	PodPredictedArrivalLt NullableTime `json:"pod_predicted_arrival_lt,omitempty"`
+	PodPredictedArrivalLt NullableString `json:"pod_predicted_arrival_lt,omitempty"`
 	// Portcast Predicted Time of Departure for the Final Vessel from the Port of Discharge (POD) - Local Time
-	PodPredictedDepartureLt NullableTime `json:"pod_predicted_departure_lt,omitempty"`
+	PodPredictedDepartureLt NullableString `json:"pod_predicted_departure_lt,omitempty"`
 	// Scheduled Time of Arrival for the Final Vessel at the Port of Discharge (POD) as per carrier T&T - Local Time
-	PodScheduledArrivalLt NullableTime `json:"pod_scheduled_arrival_lt,omitempty"`
+	PodScheduledArrivalLt NullableString `json:"pod_scheduled_arrival_lt,omitempty"`
 	// First Recorded Scheduled Time of Arrival for the Final Vessel at the Port of Discharge (POD) as per carrier T&T - Local Time
 	PodScheduledArrivalLtFirstSeen NullableString `json:"pod_scheduled_arrival_lt_first_seen,omitempty"`
 	// Scheduled Time of Arrival for the Final Vessel at the Port of Discharge (POD) as per vessel schedule - Local Time
-	PodScheduledArrivalLtFromSchedule NullableTime `json:"pod_scheduled_arrival_lt_from_schedule,omitempty"`
+	PodScheduledArrivalLtFromSchedule NullableString `json:"pod_scheduled_arrival_lt_from_schedule,omitempty"`
 	// Scheduled Time of Departure for the Final Vessel from the Port of Discharge (POD) as per vessel schedule - Local Time
-	PodScheduledDepartureLtFromSchedule NullableTime `json:"pod_scheduled_departure_lt_from_schedule,omitempty"`
+	PodScheduledDepartureLtFromSchedule NullableString `json:"pod_scheduled_departure_lt_from_schedule,omitempty"`
 	// Carrier Scheduled Container Discharge Time from Final Vessel at the Port of Discharge (POD) - Local Time
-	PodScheduledDischargeLt NullableTime `json:"pod_scheduled_discharge_lt,omitempty"`
+	PodScheduledDischargeLt NullableString `json:"pod_scheduled_discharge_lt,omitempty"`
 	// Terminal Name for the Port of Discharge (POD)
 	PodTerminalName *string `json:"pod_terminal_name,omitempty"`
 	// UNLOCODE for the Port of Loading
 	Pol *string `json:"pol,omitempty"`
 	// Actual Time of Arrival for the First Vessel at the Port of Loading (POL) as per AIS Data - Local Time
-	PolActualArrivalLtFromAis NullableTime `json:"pol_actual_arrival_lt_from_ais,omitempty"`
+	PolActualArrivalLtFromAis NullableString `json:"pol_actual_arrival_lt_from_ais,omitempty"`
 	// Actual Time of Departure for the First Vessel from the Port of Loading (POL) - Local Time
-	PolActualDepartureLt NullableTime `json:"pol_actual_departure_lt,omitempty"`
+	PolActualDepartureLt NullableString `json:"pol_actual_departure_lt,omitempty"`
 	// Actual Time of Departure for the First Vessel from the Port of Loading (POL) as per AIS Data - Local Time
-	PolActualDepartureLtFromAis NullableTime `json:"pol_actual_departure_lt_from_ais,omitempty"`
+	PolActualDepartureLtFromAis NullableString `json:"pol_actual_departure_lt_from_ais,omitempty"`
 	// Actual Container Loading Time on First Vessel at the Port of Loading (POL) - Local Time
-	PolActualLoadingLt NullableTime `json:"pol_actual_loading_lt,omitempty"`
+	PolActualLoadingLt NullableString `json:"pol_actual_loading_lt,omitempty"`
 	// Port of Loading Name
 	PolName *string `json:"pol_name,omitempty"`
 	// Portcast Predicted Time of Arrival for the First Vessel at the Port of Loading (POL) - Local Time
-	PolPredictedArrivalLt NullableTime `json:"pol_predicted_arrival_lt,omitempty"`
+	PolPredictedArrivalLt NullableString `json:"pol_predicted_arrival_lt,omitempty"`
 	// Portcast Predicted Time of Departure for the First Vessel from the Port of Loading (POL) - Local Time [Most Reliable Source of ETD]
-	PolPredictedDepartureLt NullableTime `json:"pol_predicted_departure_lt,omitempty"`
+	PolPredictedDepartureLt NullableString `json:"pol_predicted_departure_lt,omitempty"`
 	// Scheduled Time of Arrival for the First Vessel at the Port of Loading (POL) as per Vessel Schedule - Local Time
-	PolScheduledArrivalLtFromSchedule NullableTime `json:"pol_scheduled_arrival_lt_from_schedule,omitempty"`
+	PolScheduledArrivalLtFromSchedule NullableString `json:"pol_scheduled_arrival_lt_from_schedule,omitempty"`
 	// Scheduled Time of Departure for the First Vessel from the Port of Loading (POL) as per Container T&T - Local Time
-	PolScheduledDepartureLt NullableTime `json:"pol_scheduled_departure_lt,omitempty"`
+	PolScheduledDepartureLt NullableString `json:"pol_scheduled_departure_lt,omitempty"`
 	// First Recorded Scheduled Time of Departure for the First Vessel at the Port of Loading (POL) as per carrier T&T - Local Time
 	PolScheduledDepartureLtFirstSeen NullableString `json:"pol_scheduled_departure_lt_first_seen,omitempty"`
 	// Scheduled Time of Departure for the First Vessel from the Port of Loading (POL) as per Vessel Schedule - Local Time
-	PolScheduledDepartureLtFromSchedule NullableTime `json:"pol_scheduled_departure_lt_from_schedule,omitempty"`
+	PolScheduledDepartureLtFromSchedule NullableString `json:"pol_scheduled_departure_lt_from_schedule,omitempty"`
 	// Carrier Scheduled Container Loading Time on First Vessel at the Port of Loading (POL) - Local Time
-	PolScheduledLoadingLt NullableTime `json:"pol_scheduled_loading_lt,omitempty"`
+	PolScheduledLoadingLt NullableString `json:"pol_scheduled_loading_lt,omitempty"`
 	// Terminal Name for the Port of Loading (POL)
 	PolTerminalName *string `json:"pol_terminal_name,omitempty"`
 	// Bill of Lading Object Updated Date
@@ -437,9 +437,9 @@ func (o *BillOfLading) SetPod(v string) {
 }
 
 // GetPodActualArrivalLt returns the PodActualArrivalLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPodActualArrivalLt() time.Time {
+func (o *BillOfLading) GetPodActualArrivalLt() string {
 	if o == nil || IsNil(o.PodActualArrivalLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodActualArrivalLt.Get()
@@ -448,7 +448,7 @@ func (o *BillOfLading) GetPodActualArrivalLt() time.Time {
 // GetPodActualArrivalLtOk returns a tuple with the PodActualArrivalLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPodActualArrivalLtOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPodActualArrivalLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -464,8 +464,8 @@ func (o *BillOfLading) HasPodActualArrivalLt() bool {
 	return false
 }
 
-// SetPodActualArrivalLt gets a reference to the given NullableTime and assigns it to the PodActualArrivalLt field.
-func (o *BillOfLading) SetPodActualArrivalLt(v time.Time) {
+// SetPodActualArrivalLt gets a reference to the given NullableString and assigns it to the PodActualArrivalLt field.
+func (o *BillOfLading) SetPodActualArrivalLt(v string) {
 	o.PodActualArrivalLt.Set(&v)
 }
 // SetPodActualArrivalLtNil sets the value for PodActualArrivalLt to be an explicit nil
@@ -479,9 +479,9 @@ func (o *BillOfLading) UnsetPodActualArrivalLt() {
 }
 
 // GetPodActualArrivalLtFromAis returns the PodActualArrivalLtFromAis field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPodActualArrivalLtFromAis() time.Time {
+func (o *BillOfLading) GetPodActualArrivalLtFromAis() string {
 	if o == nil || IsNil(o.PodActualArrivalLtFromAis.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodActualArrivalLtFromAis.Get()
@@ -490,7 +490,7 @@ func (o *BillOfLading) GetPodActualArrivalLtFromAis() time.Time {
 // GetPodActualArrivalLtFromAisOk returns a tuple with the PodActualArrivalLtFromAis field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPodActualArrivalLtFromAisOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPodActualArrivalLtFromAisOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -506,8 +506,8 @@ func (o *BillOfLading) HasPodActualArrivalLtFromAis() bool {
 	return false
 }
 
-// SetPodActualArrivalLtFromAis gets a reference to the given NullableTime and assigns it to the PodActualArrivalLtFromAis field.
-func (o *BillOfLading) SetPodActualArrivalLtFromAis(v time.Time) {
+// SetPodActualArrivalLtFromAis gets a reference to the given NullableString and assigns it to the PodActualArrivalLtFromAis field.
+func (o *BillOfLading) SetPodActualArrivalLtFromAis(v string) {
 	o.PodActualArrivalLtFromAis.Set(&v)
 }
 // SetPodActualArrivalLtFromAisNil sets the value for PodActualArrivalLtFromAis to be an explicit nil
@@ -521,9 +521,9 @@ func (o *BillOfLading) UnsetPodActualArrivalLtFromAis() {
 }
 
 // GetPodActualDepartureLtFromAis returns the PodActualDepartureLtFromAis field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPodActualDepartureLtFromAis() time.Time {
+func (o *BillOfLading) GetPodActualDepartureLtFromAis() string {
 	if o == nil || IsNil(o.PodActualDepartureLtFromAis.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodActualDepartureLtFromAis.Get()
@@ -532,7 +532,7 @@ func (o *BillOfLading) GetPodActualDepartureLtFromAis() time.Time {
 // GetPodActualDepartureLtFromAisOk returns a tuple with the PodActualDepartureLtFromAis field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPodActualDepartureLtFromAisOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPodActualDepartureLtFromAisOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -548,8 +548,8 @@ func (o *BillOfLading) HasPodActualDepartureLtFromAis() bool {
 	return false
 }
 
-// SetPodActualDepartureLtFromAis gets a reference to the given NullableTime and assigns it to the PodActualDepartureLtFromAis field.
-func (o *BillOfLading) SetPodActualDepartureLtFromAis(v time.Time) {
+// SetPodActualDepartureLtFromAis gets a reference to the given NullableString and assigns it to the PodActualDepartureLtFromAis field.
+func (o *BillOfLading) SetPodActualDepartureLtFromAis(v string) {
 	o.PodActualDepartureLtFromAis.Set(&v)
 }
 // SetPodActualDepartureLtFromAisNil sets the value for PodActualDepartureLtFromAis to be an explicit nil
@@ -563,9 +563,9 @@ func (o *BillOfLading) UnsetPodActualDepartureLtFromAis() {
 }
 
 // GetPodActualDischargeLt returns the PodActualDischargeLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPodActualDischargeLt() time.Time {
+func (o *BillOfLading) GetPodActualDischargeLt() string {
 	if o == nil || IsNil(o.PodActualDischargeLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodActualDischargeLt.Get()
@@ -574,7 +574,7 @@ func (o *BillOfLading) GetPodActualDischargeLt() time.Time {
 // GetPodActualDischargeLtOk returns a tuple with the PodActualDischargeLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPodActualDischargeLtOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPodActualDischargeLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -590,8 +590,8 @@ func (o *BillOfLading) HasPodActualDischargeLt() bool {
 	return false
 }
 
-// SetPodActualDischargeLt gets a reference to the given NullableTime and assigns it to the PodActualDischargeLt field.
-func (o *BillOfLading) SetPodActualDischargeLt(v time.Time) {
+// SetPodActualDischargeLt gets a reference to the given NullableString and assigns it to the PodActualDischargeLt field.
+func (o *BillOfLading) SetPodActualDischargeLt(v string) {
 	o.PodActualDischargeLt.Set(&v)
 }
 // SetPodActualDischargeLtNil sets the value for PodActualDischargeLt to be an explicit nil
@@ -637,9 +637,9 @@ func (o *BillOfLading) SetPodName(v string) {
 }
 
 // GetPodPredictedArrivalLt returns the PodPredictedArrivalLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPodPredictedArrivalLt() time.Time {
+func (o *BillOfLading) GetPodPredictedArrivalLt() string {
 	if o == nil || IsNil(o.PodPredictedArrivalLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodPredictedArrivalLt.Get()
@@ -648,7 +648,7 @@ func (o *BillOfLading) GetPodPredictedArrivalLt() time.Time {
 // GetPodPredictedArrivalLtOk returns a tuple with the PodPredictedArrivalLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPodPredictedArrivalLtOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPodPredictedArrivalLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -664,8 +664,8 @@ func (o *BillOfLading) HasPodPredictedArrivalLt() bool {
 	return false
 }
 
-// SetPodPredictedArrivalLt gets a reference to the given NullableTime and assigns it to the PodPredictedArrivalLt field.
-func (o *BillOfLading) SetPodPredictedArrivalLt(v time.Time) {
+// SetPodPredictedArrivalLt gets a reference to the given NullableString and assigns it to the PodPredictedArrivalLt field.
+func (o *BillOfLading) SetPodPredictedArrivalLt(v string) {
 	o.PodPredictedArrivalLt.Set(&v)
 }
 // SetPodPredictedArrivalLtNil sets the value for PodPredictedArrivalLt to be an explicit nil
@@ -679,9 +679,9 @@ func (o *BillOfLading) UnsetPodPredictedArrivalLt() {
 }
 
 // GetPodPredictedDepartureLt returns the PodPredictedDepartureLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPodPredictedDepartureLt() time.Time {
+func (o *BillOfLading) GetPodPredictedDepartureLt() string {
 	if o == nil || IsNil(o.PodPredictedDepartureLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodPredictedDepartureLt.Get()
@@ -690,7 +690,7 @@ func (o *BillOfLading) GetPodPredictedDepartureLt() time.Time {
 // GetPodPredictedDepartureLtOk returns a tuple with the PodPredictedDepartureLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPodPredictedDepartureLtOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPodPredictedDepartureLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -706,8 +706,8 @@ func (o *BillOfLading) HasPodPredictedDepartureLt() bool {
 	return false
 }
 
-// SetPodPredictedDepartureLt gets a reference to the given NullableTime and assigns it to the PodPredictedDepartureLt field.
-func (o *BillOfLading) SetPodPredictedDepartureLt(v time.Time) {
+// SetPodPredictedDepartureLt gets a reference to the given NullableString and assigns it to the PodPredictedDepartureLt field.
+func (o *BillOfLading) SetPodPredictedDepartureLt(v string) {
 	o.PodPredictedDepartureLt.Set(&v)
 }
 // SetPodPredictedDepartureLtNil sets the value for PodPredictedDepartureLt to be an explicit nil
@@ -721,9 +721,9 @@ func (o *BillOfLading) UnsetPodPredictedDepartureLt() {
 }
 
 // GetPodScheduledArrivalLt returns the PodScheduledArrivalLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPodScheduledArrivalLt() time.Time {
+func (o *BillOfLading) GetPodScheduledArrivalLt() string {
 	if o == nil || IsNil(o.PodScheduledArrivalLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodScheduledArrivalLt.Get()
@@ -732,7 +732,7 @@ func (o *BillOfLading) GetPodScheduledArrivalLt() time.Time {
 // GetPodScheduledArrivalLtOk returns a tuple with the PodScheduledArrivalLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPodScheduledArrivalLtOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPodScheduledArrivalLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -748,8 +748,8 @@ func (o *BillOfLading) HasPodScheduledArrivalLt() bool {
 	return false
 }
 
-// SetPodScheduledArrivalLt gets a reference to the given NullableTime and assigns it to the PodScheduledArrivalLt field.
-func (o *BillOfLading) SetPodScheduledArrivalLt(v time.Time) {
+// SetPodScheduledArrivalLt gets a reference to the given NullableString and assigns it to the PodScheduledArrivalLt field.
+func (o *BillOfLading) SetPodScheduledArrivalLt(v string) {
 	o.PodScheduledArrivalLt.Set(&v)
 }
 // SetPodScheduledArrivalLtNil sets the value for PodScheduledArrivalLt to be an explicit nil
@@ -805,9 +805,9 @@ func (o *BillOfLading) UnsetPodScheduledArrivalLtFirstSeen() {
 }
 
 // GetPodScheduledArrivalLtFromSchedule returns the PodScheduledArrivalLtFromSchedule field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPodScheduledArrivalLtFromSchedule() time.Time {
+func (o *BillOfLading) GetPodScheduledArrivalLtFromSchedule() string {
 	if o == nil || IsNil(o.PodScheduledArrivalLtFromSchedule.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodScheduledArrivalLtFromSchedule.Get()
@@ -816,7 +816,7 @@ func (o *BillOfLading) GetPodScheduledArrivalLtFromSchedule() time.Time {
 // GetPodScheduledArrivalLtFromScheduleOk returns a tuple with the PodScheduledArrivalLtFromSchedule field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPodScheduledArrivalLtFromScheduleOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPodScheduledArrivalLtFromScheduleOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -832,8 +832,8 @@ func (o *BillOfLading) HasPodScheduledArrivalLtFromSchedule() bool {
 	return false
 }
 
-// SetPodScheduledArrivalLtFromSchedule gets a reference to the given NullableTime and assigns it to the PodScheduledArrivalLtFromSchedule field.
-func (o *BillOfLading) SetPodScheduledArrivalLtFromSchedule(v time.Time) {
+// SetPodScheduledArrivalLtFromSchedule gets a reference to the given NullableString and assigns it to the PodScheduledArrivalLtFromSchedule field.
+func (o *BillOfLading) SetPodScheduledArrivalLtFromSchedule(v string) {
 	o.PodScheduledArrivalLtFromSchedule.Set(&v)
 }
 // SetPodScheduledArrivalLtFromScheduleNil sets the value for PodScheduledArrivalLtFromSchedule to be an explicit nil
@@ -847,9 +847,9 @@ func (o *BillOfLading) UnsetPodScheduledArrivalLtFromSchedule() {
 }
 
 // GetPodScheduledDepartureLtFromSchedule returns the PodScheduledDepartureLtFromSchedule field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPodScheduledDepartureLtFromSchedule() time.Time {
+func (o *BillOfLading) GetPodScheduledDepartureLtFromSchedule() string {
 	if o == nil || IsNil(o.PodScheduledDepartureLtFromSchedule.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodScheduledDepartureLtFromSchedule.Get()
@@ -858,7 +858,7 @@ func (o *BillOfLading) GetPodScheduledDepartureLtFromSchedule() time.Time {
 // GetPodScheduledDepartureLtFromScheduleOk returns a tuple with the PodScheduledDepartureLtFromSchedule field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPodScheduledDepartureLtFromScheduleOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPodScheduledDepartureLtFromScheduleOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -874,8 +874,8 @@ func (o *BillOfLading) HasPodScheduledDepartureLtFromSchedule() bool {
 	return false
 }
 
-// SetPodScheduledDepartureLtFromSchedule gets a reference to the given NullableTime and assigns it to the PodScheduledDepartureLtFromSchedule field.
-func (o *BillOfLading) SetPodScheduledDepartureLtFromSchedule(v time.Time) {
+// SetPodScheduledDepartureLtFromSchedule gets a reference to the given NullableString and assigns it to the PodScheduledDepartureLtFromSchedule field.
+func (o *BillOfLading) SetPodScheduledDepartureLtFromSchedule(v string) {
 	o.PodScheduledDepartureLtFromSchedule.Set(&v)
 }
 // SetPodScheduledDepartureLtFromScheduleNil sets the value for PodScheduledDepartureLtFromSchedule to be an explicit nil
@@ -889,9 +889,9 @@ func (o *BillOfLading) UnsetPodScheduledDepartureLtFromSchedule() {
 }
 
 // GetPodScheduledDischargeLt returns the PodScheduledDischargeLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPodScheduledDischargeLt() time.Time {
+func (o *BillOfLading) GetPodScheduledDischargeLt() string {
 	if o == nil || IsNil(o.PodScheduledDischargeLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodScheduledDischargeLt.Get()
@@ -900,7 +900,7 @@ func (o *BillOfLading) GetPodScheduledDischargeLt() time.Time {
 // GetPodScheduledDischargeLtOk returns a tuple with the PodScheduledDischargeLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPodScheduledDischargeLtOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPodScheduledDischargeLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -916,8 +916,8 @@ func (o *BillOfLading) HasPodScheduledDischargeLt() bool {
 	return false
 }
 
-// SetPodScheduledDischargeLt gets a reference to the given NullableTime and assigns it to the PodScheduledDischargeLt field.
-func (o *BillOfLading) SetPodScheduledDischargeLt(v time.Time) {
+// SetPodScheduledDischargeLt gets a reference to the given NullableString and assigns it to the PodScheduledDischargeLt field.
+func (o *BillOfLading) SetPodScheduledDischargeLt(v string) {
 	o.PodScheduledDischargeLt.Set(&v)
 }
 // SetPodScheduledDischargeLtNil sets the value for PodScheduledDischargeLt to be an explicit nil
@@ -995,9 +995,9 @@ func (o *BillOfLading) SetPol(v string) {
 }
 
 // GetPolActualArrivalLtFromAis returns the PolActualArrivalLtFromAis field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPolActualArrivalLtFromAis() time.Time {
+func (o *BillOfLading) GetPolActualArrivalLtFromAis() string {
 	if o == nil || IsNil(o.PolActualArrivalLtFromAis.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolActualArrivalLtFromAis.Get()
@@ -1006,7 +1006,7 @@ func (o *BillOfLading) GetPolActualArrivalLtFromAis() time.Time {
 // GetPolActualArrivalLtFromAisOk returns a tuple with the PolActualArrivalLtFromAis field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPolActualArrivalLtFromAisOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPolActualArrivalLtFromAisOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -1022,8 +1022,8 @@ func (o *BillOfLading) HasPolActualArrivalLtFromAis() bool {
 	return false
 }
 
-// SetPolActualArrivalLtFromAis gets a reference to the given NullableTime and assigns it to the PolActualArrivalLtFromAis field.
-func (o *BillOfLading) SetPolActualArrivalLtFromAis(v time.Time) {
+// SetPolActualArrivalLtFromAis gets a reference to the given NullableString and assigns it to the PolActualArrivalLtFromAis field.
+func (o *BillOfLading) SetPolActualArrivalLtFromAis(v string) {
 	o.PolActualArrivalLtFromAis.Set(&v)
 }
 // SetPolActualArrivalLtFromAisNil sets the value for PolActualArrivalLtFromAis to be an explicit nil
@@ -1037,9 +1037,9 @@ func (o *BillOfLading) UnsetPolActualArrivalLtFromAis() {
 }
 
 // GetPolActualDepartureLt returns the PolActualDepartureLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPolActualDepartureLt() time.Time {
+func (o *BillOfLading) GetPolActualDepartureLt() string {
 	if o == nil || IsNil(o.PolActualDepartureLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolActualDepartureLt.Get()
@@ -1048,7 +1048,7 @@ func (o *BillOfLading) GetPolActualDepartureLt() time.Time {
 // GetPolActualDepartureLtOk returns a tuple with the PolActualDepartureLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPolActualDepartureLtOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPolActualDepartureLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -1064,8 +1064,8 @@ func (o *BillOfLading) HasPolActualDepartureLt() bool {
 	return false
 }
 
-// SetPolActualDepartureLt gets a reference to the given NullableTime and assigns it to the PolActualDepartureLt field.
-func (o *BillOfLading) SetPolActualDepartureLt(v time.Time) {
+// SetPolActualDepartureLt gets a reference to the given NullableString and assigns it to the PolActualDepartureLt field.
+func (o *BillOfLading) SetPolActualDepartureLt(v string) {
 	o.PolActualDepartureLt.Set(&v)
 }
 // SetPolActualDepartureLtNil sets the value for PolActualDepartureLt to be an explicit nil
@@ -1079,9 +1079,9 @@ func (o *BillOfLading) UnsetPolActualDepartureLt() {
 }
 
 // GetPolActualDepartureLtFromAis returns the PolActualDepartureLtFromAis field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPolActualDepartureLtFromAis() time.Time {
+func (o *BillOfLading) GetPolActualDepartureLtFromAis() string {
 	if o == nil || IsNil(o.PolActualDepartureLtFromAis.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolActualDepartureLtFromAis.Get()
@@ -1090,7 +1090,7 @@ func (o *BillOfLading) GetPolActualDepartureLtFromAis() time.Time {
 // GetPolActualDepartureLtFromAisOk returns a tuple with the PolActualDepartureLtFromAis field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPolActualDepartureLtFromAisOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPolActualDepartureLtFromAisOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -1106,8 +1106,8 @@ func (o *BillOfLading) HasPolActualDepartureLtFromAis() bool {
 	return false
 }
 
-// SetPolActualDepartureLtFromAis gets a reference to the given NullableTime and assigns it to the PolActualDepartureLtFromAis field.
-func (o *BillOfLading) SetPolActualDepartureLtFromAis(v time.Time) {
+// SetPolActualDepartureLtFromAis gets a reference to the given NullableString and assigns it to the PolActualDepartureLtFromAis field.
+func (o *BillOfLading) SetPolActualDepartureLtFromAis(v string) {
 	o.PolActualDepartureLtFromAis.Set(&v)
 }
 // SetPolActualDepartureLtFromAisNil sets the value for PolActualDepartureLtFromAis to be an explicit nil
@@ -1121,9 +1121,9 @@ func (o *BillOfLading) UnsetPolActualDepartureLtFromAis() {
 }
 
 // GetPolActualLoadingLt returns the PolActualLoadingLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPolActualLoadingLt() time.Time {
+func (o *BillOfLading) GetPolActualLoadingLt() string {
 	if o == nil || IsNil(o.PolActualLoadingLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolActualLoadingLt.Get()
@@ -1132,7 +1132,7 @@ func (o *BillOfLading) GetPolActualLoadingLt() time.Time {
 // GetPolActualLoadingLtOk returns a tuple with the PolActualLoadingLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPolActualLoadingLtOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPolActualLoadingLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -1148,8 +1148,8 @@ func (o *BillOfLading) HasPolActualLoadingLt() bool {
 	return false
 }
 
-// SetPolActualLoadingLt gets a reference to the given NullableTime and assigns it to the PolActualLoadingLt field.
-func (o *BillOfLading) SetPolActualLoadingLt(v time.Time) {
+// SetPolActualLoadingLt gets a reference to the given NullableString and assigns it to the PolActualLoadingLt field.
+func (o *BillOfLading) SetPolActualLoadingLt(v string) {
 	o.PolActualLoadingLt.Set(&v)
 }
 // SetPolActualLoadingLtNil sets the value for PolActualLoadingLt to be an explicit nil
@@ -1195,9 +1195,9 @@ func (o *BillOfLading) SetPolName(v string) {
 }
 
 // GetPolPredictedArrivalLt returns the PolPredictedArrivalLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPolPredictedArrivalLt() time.Time {
+func (o *BillOfLading) GetPolPredictedArrivalLt() string {
 	if o == nil || IsNil(o.PolPredictedArrivalLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolPredictedArrivalLt.Get()
@@ -1206,7 +1206,7 @@ func (o *BillOfLading) GetPolPredictedArrivalLt() time.Time {
 // GetPolPredictedArrivalLtOk returns a tuple with the PolPredictedArrivalLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPolPredictedArrivalLtOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPolPredictedArrivalLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -1222,8 +1222,8 @@ func (o *BillOfLading) HasPolPredictedArrivalLt() bool {
 	return false
 }
 
-// SetPolPredictedArrivalLt gets a reference to the given NullableTime and assigns it to the PolPredictedArrivalLt field.
-func (o *BillOfLading) SetPolPredictedArrivalLt(v time.Time) {
+// SetPolPredictedArrivalLt gets a reference to the given NullableString and assigns it to the PolPredictedArrivalLt field.
+func (o *BillOfLading) SetPolPredictedArrivalLt(v string) {
 	o.PolPredictedArrivalLt.Set(&v)
 }
 // SetPolPredictedArrivalLtNil sets the value for PolPredictedArrivalLt to be an explicit nil
@@ -1237,9 +1237,9 @@ func (o *BillOfLading) UnsetPolPredictedArrivalLt() {
 }
 
 // GetPolPredictedDepartureLt returns the PolPredictedDepartureLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPolPredictedDepartureLt() time.Time {
+func (o *BillOfLading) GetPolPredictedDepartureLt() string {
 	if o == nil || IsNil(o.PolPredictedDepartureLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolPredictedDepartureLt.Get()
@@ -1248,7 +1248,7 @@ func (o *BillOfLading) GetPolPredictedDepartureLt() time.Time {
 // GetPolPredictedDepartureLtOk returns a tuple with the PolPredictedDepartureLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPolPredictedDepartureLtOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPolPredictedDepartureLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -1264,8 +1264,8 @@ func (o *BillOfLading) HasPolPredictedDepartureLt() bool {
 	return false
 }
 
-// SetPolPredictedDepartureLt gets a reference to the given NullableTime and assigns it to the PolPredictedDepartureLt field.
-func (o *BillOfLading) SetPolPredictedDepartureLt(v time.Time) {
+// SetPolPredictedDepartureLt gets a reference to the given NullableString and assigns it to the PolPredictedDepartureLt field.
+func (o *BillOfLading) SetPolPredictedDepartureLt(v string) {
 	o.PolPredictedDepartureLt.Set(&v)
 }
 // SetPolPredictedDepartureLtNil sets the value for PolPredictedDepartureLt to be an explicit nil
@@ -1279,9 +1279,9 @@ func (o *BillOfLading) UnsetPolPredictedDepartureLt() {
 }
 
 // GetPolScheduledArrivalLtFromSchedule returns the PolScheduledArrivalLtFromSchedule field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPolScheduledArrivalLtFromSchedule() time.Time {
+func (o *BillOfLading) GetPolScheduledArrivalLtFromSchedule() string {
 	if o == nil || IsNil(o.PolScheduledArrivalLtFromSchedule.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolScheduledArrivalLtFromSchedule.Get()
@@ -1290,7 +1290,7 @@ func (o *BillOfLading) GetPolScheduledArrivalLtFromSchedule() time.Time {
 // GetPolScheduledArrivalLtFromScheduleOk returns a tuple with the PolScheduledArrivalLtFromSchedule field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPolScheduledArrivalLtFromScheduleOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPolScheduledArrivalLtFromScheduleOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -1306,8 +1306,8 @@ func (o *BillOfLading) HasPolScheduledArrivalLtFromSchedule() bool {
 	return false
 }
 
-// SetPolScheduledArrivalLtFromSchedule gets a reference to the given NullableTime and assigns it to the PolScheduledArrivalLtFromSchedule field.
-func (o *BillOfLading) SetPolScheduledArrivalLtFromSchedule(v time.Time) {
+// SetPolScheduledArrivalLtFromSchedule gets a reference to the given NullableString and assigns it to the PolScheduledArrivalLtFromSchedule field.
+func (o *BillOfLading) SetPolScheduledArrivalLtFromSchedule(v string) {
 	o.PolScheduledArrivalLtFromSchedule.Set(&v)
 }
 // SetPolScheduledArrivalLtFromScheduleNil sets the value for PolScheduledArrivalLtFromSchedule to be an explicit nil
@@ -1321,9 +1321,9 @@ func (o *BillOfLading) UnsetPolScheduledArrivalLtFromSchedule() {
 }
 
 // GetPolScheduledDepartureLt returns the PolScheduledDepartureLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPolScheduledDepartureLt() time.Time {
+func (o *BillOfLading) GetPolScheduledDepartureLt() string {
 	if o == nil || IsNil(o.PolScheduledDepartureLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolScheduledDepartureLt.Get()
@@ -1332,7 +1332,7 @@ func (o *BillOfLading) GetPolScheduledDepartureLt() time.Time {
 // GetPolScheduledDepartureLtOk returns a tuple with the PolScheduledDepartureLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPolScheduledDepartureLtOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPolScheduledDepartureLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -1348,8 +1348,8 @@ func (o *BillOfLading) HasPolScheduledDepartureLt() bool {
 	return false
 }
 
-// SetPolScheduledDepartureLt gets a reference to the given NullableTime and assigns it to the PolScheduledDepartureLt field.
-func (o *BillOfLading) SetPolScheduledDepartureLt(v time.Time) {
+// SetPolScheduledDepartureLt gets a reference to the given NullableString and assigns it to the PolScheduledDepartureLt field.
+func (o *BillOfLading) SetPolScheduledDepartureLt(v string) {
 	o.PolScheduledDepartureLt.Set(&v)
 }
 // SetPolScheduledDepartureLtNil sets the value for PolScheduledDepartureLt to be an explicit nil
@@ -1405,9 +1405,9 @@ func (o *BillOfLading) UnsetPolScheduledDepartureLtFirstSeen() {
 }
 
 // GetPolScheduledDepartureLtFromSchedule returns the PolScheduledDepartureLtFromSchedule field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPolScheduledDepartureLtFromSchedule() time.Time {
+func (o *BillOfLading) GetPolScheduledDepartureLtFromSchedule() string {
 	if o == nil || IsNil(o.PolScheduledDepartureLtFromSchedule.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolScheduledDepartureLtFromSchedule.Get()
@@ -1416,7 +1416,7 @@ func (o *BillOfLading) GetPolScheduledDepartureLtFromSchedule() time.Time {
 // GetPolScheduledDepartureLtFromScheduleOk returns a tuple with the PolScheduledDepartureLtFromSchedule field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPolScheduledDepartureLtFromScheduleOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPolScheduledDepartureLtFromScheduleOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -1432,8 +1432,8 @@ func (o *BillOfLading) HasPolScheduledDepartureLtFromSchedule() bool {
 	return false
 }
 
-// SetPolScheduledDepartureLtFromSchedule gets a reference to the given NullableTime and assigns it to the PolScheduledDepartureLtFromSchedule field.
-func (o *BillOfLading) SetPolScheduledDepartureLtFromSchedule(v time.Time) {
+// SetPolScheduledDepartureLtFromSchedule gets a reference to the given NullableString and assigns it to the PolScheduledDepartureLtFromSchedule field.
+func (o *BillOfLading) SetPolScheduledDepartureLtFromSchedule(v string) {
 	o.PolScheduledDepartureLtFromSchedule.Set(&v)
 }
 // SetPolScheduledDepartureLtFromScheduleNil sets the value for PolScheduledDepartureLtFromSchedule to be an explicit nil
@@ -1447,9 +1447,9 @@ func (o *BillOfLading) UnsetPolScheduledDepartureLtFromSchedule() {
 }
 
 // GetPolScheduledLoadingLt returns the PolScheduledLoadingLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *BillOfLading) GetPolScheduledLoadingLt() time.Time {
+func (o *BillOfLading) GetPolScheduledLoadingLt() string {
 	if o == nil || IsNil(o.PolScheduledLoadingLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolScheduledLoadingLt.Get()
@@ -1458,7 +1458,7 @@ func (o *BillOfLading) GetPolScheduledLoadingLt() time.Time {
 // GetPolScheduledLoadingLtOk returns a tuple with the PolScheduledLoadingLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *BillOfLading) GetPolScheduledLoadingLtOk() (*time.Time, bool) {
+func (o *BillOfLading) GetPolScheduledLoadingLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -1474,8 +1474,8 @@ func (o *BillOfLading) HasPolScheduledLoadingLt() bool {
 	return false
 }
 
-// SetPolScheduledLoadingLt gets a reference to the given NullableTime and assigns it to the PolScheduledLoadingLt field.
-func (o *BillOfLading) SetPolScheduledLoadingLt(v time.Time) {
+// SetPolScheduledLoadingLt gets a reference to the given NullableString and assigns it to the PolScheduledLoadingLt field.
+func (o *BillOfLading) SetPolScheduledLoadingLt(v string) {
 	o.PolScheduledLoadingLt.Set(&v)
 }
 // SetPolScheduledLoadingLtNil sets the value for PolScheduledLoadingLt to be an explicit nil

--- a/portcast/model_port_terminal_add_on_export_plan.go
+++ b/portcast/model_port_terminal_add_on_export_plan.go
@@ -38,23 +38,23 @@ type PortTerminalAddOnExportPlan struct {
 	// Voyage Number associated with the export journey, as reported by the Terminal.
 	VoyageNo *string `json:"voyage_no,omitempty"`
 	// Earliest Receipt Date (ERD) for a standard container, as reported by the terminal - Local Time.
-	ErdStandard *time.Time `json:"erd_standard,omitempty"`
+	ErdStandard *string `json:"erd_standard,omitempty"`
 	// Earliest Receipt Date (ERD) for a reefer container, as reported by the terminal - Local Time.
-	ErdReefer *time.Time `json:"erd_reefer,omitempty"`
+	ErdReefer *string `json:"erd_reefer,omitempty"`
 	// Date a container was received at the terminal through the gate, as reported by the terminal - Local Time.
 	GateInDate *string `json:"gate_in_date,omitempty"`
 	// Last possible date and time for gating-in standard container at the export terminal, as reported by the Terminal - Local Time.
-	PortCutoffStandard *time.Time `json:"port_cutoff_standard,omitempty"`
+	PortCutoffStandard *string `json:"port_cutoff_standard,omitempty"`
 	// Last possible date and time for gating-in reefer container at the export terminal, as reported by the terminal - Local Time.
-	PortCutoffReefer *time.Time `json:"port_cutoff_reefer,omitempty"`
+	PortCutoffReefer *string `json:"port_cutoff_reefer,omitempty"`
 	// Latest vessel ETA to the export port, as reported by the terminal - Local Time.
-	LatestEta *time.Time `json:"latest_eta,omitempty"`
+	LatestEta *string `json:"latest_eta,omitempty"`
 	// Actual vessel time of arrival, as reported by the terminal - Local Time.
-	ActualArrival *time.Time `json:"actual_arrival,omitempty"`
+	ActualArrival *string `json:"actual_arrival,omitempty"`
 	// Latest vessel ETD from the export port, as reported by the terminal - Local Time.
-	LatestEtd *time.Time `json:"latest_etd,omitempty"`
+	LatestEtd *string `json:"latest_etd,omitempty"`
 	// Actual vessel time of departure from the export port, as reported by the terminal - Local Time.
-	ActualDeparture *time.Time `json:"actual_departure,omitempty"`
+	ActualDeparture *string `json:"actual_departure,omitempty"`
 }
 
 // NewPortTerminalAddOnExportPlan instantiates a new PortTerminalAddOnExportPlan object
@@ -331,9 +331,9 @@ func (o *PortTerminalAddOnExportPlan) SetVoyageNo(v string) {
 }
 
 // GetErdStandard returns the ErdStandard field value if set, zero value otherwise.
-func (o *PortTerminalAddOnExportPlan) GetErdStandard() time.Time {
+func (o *PortTerminalAddOnExportPlan) GetErdStandard() string {
 	if o == nil || IsNil(o.ErdStandard) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.ErdStandard
@@ -341,7 +341,7 @@ func (o *PortTerminalAddOnExportPlan) GetErdStandard() time.Time {
 
 // GetErdStandardOk returns a tuple with the ErdStandard field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *PortTerminalAddOnExportPlan) GetErdStandardOk() (*time.Time, bool) {
+func (o *PortTerminalAddOnExportPlan) GetErdStandardOk() (*string, bool) {
 	if o == nil || IsNil(o.ErdStandard) {
 		return nil, false
 	}
@@ -357,15 +357,15 @@ func (o *PortTerminalAddOnExportPlan) HasErdStandard() bool {
 	return false
 }
 
-// SetErdStandard gets a reference to the given time.Time and assigns it to the ErdStandard field.
-func (o *PortTerminalAddOnExportPlan) SetErdStandard(v time.Time) {
+// SetErdStandard gets a reference to the given string and assigns it to the ErdStandard field.
+func (o *PortTerminalAddOnExportPlan) SetErdStandard(v string) {
 	o.ErdStandard = &v
 }
 
 // GetErdReefer returns the ErdReefer field value if set, zero value otherwise.
-func (o *PortTerminalAddOnExportPlan) GetErdReefer() time.Time {
+func (o *PortTerminalAddOnExportPlan) GetErdReefer() string {
 	if o == nil || IsNil(o.ErdReefer) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.ErdReefer
@@ -373,7 +373,7 @@ func (o *PortTerminalAddOnExportPlan) GetErdReefer() time.Time {
 
 // GetErdReeferOk returns a tuple with the ErdReefer field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *PortTerminalAddOnExportPlan) GetErdReeferOk() (*time.Time, bool) {
+func (o *PortTerminalAddOnExportPlan) GetErdReeferOk() (*string, bool) {
 	if o == nil || IsNil(o.ErdReefer) {
 		return nil, false
 	}
@@ -389,8 +389,8 @@ func (o *PortTerminalAddOnExportPlan) HasErdReefer() bool {
 	return false
 }
 
-// SetErdReefer gets a reference to the given time.Time and assigns it to the ErdReefer field.
-func (o *PortTerminalAddOnExportPlan) SetErdReefer(v time.Time) {
+// SetErdReefer gets a reference to the given string and assigns it to the ErdReefer field.
+func (o *PortTerminalAddOnExportPlan) SetErdReefer(v string) {
 	o.ErdReefer = &v
 }
 
@@ -427,9 +427,9 @@ func (o *PortTerminalAddOnExportPlan) SetGateInDate(v string) {
 }
 
 // GetPortCutoffStandard returns the PortCutoffStandard field value if set, zero value otherwise.
-func (o *PortTerminalAddOnExportPlan) GetPortCutoffStandard() time.Time {
+func (o *PortTerminalAddOnExportPlan) GetPortCutoffStandard() string {
 	if o == nil || IsNil(o.PortCutoffStandard) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PortCutoffStandard
@@ -437,7 +437,7 @@ func (o *PortTerminalAddOnExportPlan) GetPortCutoffStandard() time.Time {
 
 // GetPortCutoffStandardOk returns a tuple with the PortCutoffStandard field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *PortTerminalAddOnExportPlan) GetPortCutoffStandardOk() (*time.Time, bool) {
+func (o *PortTerminalAddOnExportPlan) GetPortCutoffStandardOk() (*string, bool) {
 	if o == nil || IsNil(o.PortCutoffStandard) {
 		return nil, false
 	}
@@ -453,15 +453,15 @@ func (o *PortTerminalAddOnExportPlan) HasPortCutoffStandard() bool {
 	return false
 }
 
-// SetPortCutoffStandard gets a reference to the given time.Time and assigns it to the PortCutoffStandard field.
-func (o *PortTerminalAddOnExportPlan) SetPortCutoffStandard(v time.Time) {
+// SetPortCutoffStandard gets a reference to the given string and assigns it to the PortCutoffStandard field.
+func (o *PortTerminalAddOnExportPlan) SetPortCutoffStandard(v string) {
 	o.PortCutoffStandard = &v
 }
 
 // GetPortCutoffReefer returns the PortCutoffReefer field value if set, zero value otherwise.
-func (o *PortTerminalAddOnExportPlan) GetPortCutoffReefer() time.Time {
+func (o *PortTerminalAddOnExportPlan) GetPortCutoffReefer() string {
 	if o == nil || IsNil(o.PortCutoffReefer) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PortCutoffReefer
@@ -469,7 +469,7 @@ func (o *PortTerminalAddOnExportPlan) GetPortCutoffReefer() time.Time {
 
 // GetPortCutoffReeferOk returns a tuple with the PortCutoffReefer field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *PortTerminalAddOnExportPlan) GetPortCutoffReeferOk() (*time.Time, bool) {
+func (o *PortTerminalAddOnExportPlan) GetPortCutoffReeferOk() (*string, bool) {
 	if o == nil || IsNil(o.PortCutoffReefer) {
 		return nil, false
 	}
@@ -485,15 +485,15 @@ func (o *PortTerminalAddOnExportPlan) HasPortCutoffReefer() bool {
 	return false
 }
 
-// SetPortCutoffReefer gets a reference to the given time.Time and assigns it to the PortCutoffReefer field.
-func (o *PortTerminalAddOnExportPlan) SetPortCutoffReefer(v time.Time) {
+// SetPortCutoffReefer gets a reference to the given string and assigns it to the PortCutoffReefer field.
+func (o *PortTerminalAddOnExportPlan) SetPortCutoffReefer(v string) {
 	o.PortCutoffReefer = &v
 }
 
 // GetLatestEta returns the LatestEta field value if set, zero value otherwise.
-func (o *PortTerminalAddOnExportPlan) GetLatestEta() time.Time {
+func (o *PortTerminalAddOnExportPlan) GetLatestEta() string {
 	if o == nil || IsNil(o.LatestEta) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.LatestEta
@@ -501,7 +501,7 @@ func (o *PortTerminalAddOnExportPlan) GetLatestEta() time.Time {
 
 // GetLatestEtaOk returns a tuple with the LatestEta field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *PortTerminalAddOnExportPlan) GetLatestEtaOk() (*time.Time, bool) {
+func (o *PortTerminalAddOnExportPlan) GetLatestEtaOk() (*string, bool) {
 	if o == nil || IsNil(o.LatestEta) {
 		return nil, false
 	}
@@ -517,15 +517,15 @@ func (o *PortTerminalAddOnExportPlan) HasLatestEta() bool {
 	return false
 }
 
-// SetLatestEta gets a reference to the given time.Time and assigns it to the LatestEta field.
-func (o *PortTerminalAddOnExportPlan) SetLatestEta(v time.Time) {
+// SetLatestEta gets a reference to the given string and assigns it to the LatestEta field.
+func (o *PortTerminalAddOnExportPlan) SetLatestEta(v string) {
 	o.LatestEta = &v
 }
 
 // GetActualArrival returns the ActualArrival field value if set, zero value otherwise.
-func (o *PortTerminalAddOnExportPlan) GetActualArrival() time.Time {
+func (o *PortTerminalAddOnExportPlan) GetActualArrival() string {
 	if o == nil || IsNil(o.ActualArrival) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.ActualArrival
@@ -533,7 +533,7 @@ func (o *PortTerminalAddOnExportPlan) GetActualArrival() time.Time {
 
 // GetActualArrivalOk returns a tuple with the ActualArrival field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *PortTerminalAddOnExportPlan) GetActualArrivalOk() (*time.Time, bool) {
+func (o *PortTerminalAddOnExportPlan) GetActualArrivalOk() (*string, bool) {
 	if o == nil || IsNil(o.ActualArrival) {
 		return nil, false
 	}
@@ -549,15 +549,15 @@ func (o *PortTerminalAddOnExportPlan) HasActualArrival() bool {
 	return false
 }
 
-// SetActualArrival gets a reference to the given time.Time and assigns it to the ActualArrival field.
-func (o *PortTerminalAddOnExportPlan) SetActualArrival(v time.Time) {
+// SetActualArrival gets a reference to the given string and assigns it to the ActualArrival field.
+func (o *PortTerminalAddOnExportPlan) SetActualArrival(v string) {
 	o.ActualArrival = &v
 }
 
 // GetLatestEtd returns the LatestEtd field value if set, zero value otherwise.
-func (o *PortTerminalAddOnExportPlan) GetLatestEtd() time.Time {
+func (o *PortTerminalAddOnExportPlan) GetLatestEtd() string {
 	if o == nil || IsNil(o.LatestEtd) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.LatestEtd
@@ -565,7 +565,7 @@ func (o *PortTerminalAddOnExportPlan) GetLatestEtd() time.Time {
 
 // GetLatestEtdOk returns a tuple with the LatestEtd field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *PortTerminalAddOnExportPlan) GetLatestEtdOk() (*time.Time, bool) {
+func (o *PortTerminalAddOnExportPlan) GetLatestEtdOk() (*string, bool) {
 	if o == nil || IsNil(o.LatestEtd) {
 		return nil, false
 	}
@@ -581,15 +581,15 @@ func (o *PortTerminalAddOnExportPlan) HasLatestEtd() bool {
 	return false
 }
 
-// SetLatestEtd gets a reference to the given time.Time and assigns it to the LatestEtd field.
-func (o *PortTerminalAddOnExportPlan) SetLatestEtd(v time.Time) {
+// SetLatestEtd gets a reference to the given string and assigns it to the LatestEtd field.
+func (o *PortTerminalAddOnExportPlan) SetLatestEtd(v string) {
 	o.LatestEtd = &v
 }
 
 // GetActualDeparture returns the ActualDeparture field value if set, zero value otherwise.
-func (o *PortTerminalAddOnExportPlan) GetActualDeparture() time.Time {
+func (o *PortTerminalAddOnExportPlan) GetActualDeparture() string {
 	if o == nil || IsNil(o.ActualDeparture) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.ActualDeparture
@@ -597,7 +597,7 @@ func (o *PortTerminalAddOnExportPlan) GetActualDeparture() time.Time {
 
 // GetActualDepartureOk returns a tuple with the ActualDeparture field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *PortTerminalAddOnExportPlan) GetActualDepartureOk() (*time.Time, bool) {
+func (o *PortTerminalAddOnExportPlan) GetActualDepartureOk() (*string, bool) {
 	if o == nil || IsNil(o.ActualDeparture) {
 		return nil, false
 	}
@@ -613,8 +613,8 @@ func (o *PortTerminalAddOnExportPlan) HasActualDeparture() bool {
 	return false
 }
 
-// SetActualDeparture gets a reference to the given time.Time and assigns it to the ActualDeparture field.
-func (o *PortTerminalAddOnExportPlan) SetActualDeparture(v time.Time) {
+// SetActualDeparture gets a reference to the given string and assigns it to the ActualDeparture field.
+func (o *PortTerminalAddOnExportPlan) SetActualDeparture(v string) {
 	o.ActualDeparture = &v
 }
 

--- a/portcast/model_sailing_info_tracking_sailing_info.go
+++ b/portcast/model_sailing_info_tracking_sailing_info.go
@@ -34,53 +34,53 @@ type SailingInfoTrackingSailingInfo struct {
 	// Target Location UNLOCODE for this specific leg of the journey
 	Pod NullableString `json:"pod,omitempty"`
 	// Actual Arrival Time at the target port location - Local Time
-	PodActualArrivalLt NullableTime `json:"pod_actual_arrival_lt,omitempty"`
+	PodActualArrivalLt NullableString `json:"pod_actual_arrival_lt,omitempty"`
 	// Actual Arrival Time at the target port location as per AIS Data - Local Time
-	PodActualArrivalLtFromAis NullableTime `json:"pod_actual_arrival_lt_from_ais,omitempty"`
+	PodActualArrivalLtFromAis NullableString `json:"pod_actual_arrival_lt_from_ais,omitempty"`
 	// Actual Departure Time from the target port location as per AIS Data - Local Time
-	PodActualDepartureLtFromAis NullableTime `json:"pod_actual_departure_lt_from_ais,omitempty"`
+	PodActualDepartureLtFromAis NullableString `json:"pod_actual_departure_lt_from_ais,omitempty"`
 	// Actual Time of Discharge at the target port location - Local Time
-	PodActualDischargeLt NullableTime `json:"pod_actual_discharge_lt,omitempty"`
+	PodActualDischargeLt NullableString `json:"pod_actual_discharge_lt,omitempty"`
 	// Target Location Name for this specific leg of the journey
 	PodName NullableString `json:"pod_name,omitempty"`
 	// Portcast Predicted Time of Arrival at the target port location - Local Time
-	PodPredictedArrivalLt NullableTime `json:"pod_predicted_arrival_lt,omitempty"`
+	PodPredictedArrivalLt NullableString `json:"pod_predicted_arrival_lt,omitempty"`
 	// Portcast Predicted Time of Departure from the target port location - Local Time
-	PodPredictedDepartureLt NullableTime `json:"pod_predicted_departure_lt,omitempty"`
+	PodPredictedDepartureLt NullableString `json:"pod_predicted_departure_lt,omitempty"`
 	// Scheduled Time of Arrival at the target port location - Local Time
-	PodScheduledArrivalLt NullableTime `json:"pod_scheduled_arrival_lt,omitempty"`
+	PodScheduledArrivalLt NullableString `json:"pod_scheduled_arrival_lt,omitempty"`
 	// Scheduled Time of Arrival at the target port location as per Vessel Schedule - Local Time
-	PodScheduledArrivalLtFromSchedule NullableTime `json:"pod_scheduled_arrival_lt_from_schedule,omitempty"`
+	PodScheduledArrivalLtFromSchedule NullableString `json:"pod_scheduled_arrival_lt_from_schedule,omitempty"`
 	// Scheduled Time of Departure from the target port location as per Vessel Schedule - Local Time
-	PodScheduledDepartureLtFromSchedule NullableTime `json:"pod_scheduled_departure_lt_from_schedule,omitempty"`
+	PodScheduledDepartureLtFromSchedule NullableString `json:"pod_scheduled_departure_lt_from_schedule,omitempty"`
 	// Scheduled Discharge Time at the target port location - Local Time
-	PodScheduledDischargeLt NullableTime `json:"pod_scheduled_discharge_lt,omitempty"`
+	PodScheduledDischargeLt NullableString `json:"pod_scheduled_discharge_lt,omitempty"`
 	// Terminal Name for the Target Port for this specific leg of the journey
 	PodTerminalName NullableString `json:"pod_terminal_name,omitempty"`
 	// Starting Location UNLOCODE for this specific leg of the journey
 	Pol NullableString `json:"pol,omitempty"`
 	// Actual Time of Arrival at the starting port location as per AIS Data - Local Time
-	PolActualArrivalLtFromAis NullableTime `json:"pol_actual_arrival_lt_from_ais,omitempty"`
+	PolActualArrivalLtFromAis NullableString `json:"pol_actual_arrival_lt_from_ais,omitempty"`
 	// Actual Time of Departure from the starting port location - Local Time
-	PolActualDepartureLt NullableTime `json:"pol_actual_departure_lt,omitempty"`
+	PolActualDepartureLt NullableString `json:"pol_actual_departure_lt,omitempty"`
 	// Actual Time of Departure from the starting port location as per AIS Data - Local Time
-	PolActualDepartureLtFromAis NullableTime `json:"pol_actual_departure_lt_from_ais,omitempty"`
+	PolActualDepartureLtFromAis NullableString `json:"pol_actual_departure_lt_from_ais,omitempty"`
 	// Actual Loading Time at the starting port location - Local Time
-	PolActualLoadingLt NullableTime `json:"pol_actual_loading_lt,omitempty"`
+	PolActualLoadingLt NullableString `json:"pol_actual_loading_lt,omitempty"`
 	// Starting Location Name for this specific leg of the journey
 	PolName NullableString `json:"pol_name,omitempty"`
 	// Portcast Predicted Time of Arrival at the starting port location - Local Time
-	PolPredictedArrivalLt NullableTime `json:"pol_predicted_arrival_lt,omitempty"`
+	PolPredictedArrivalLt NullableString `json:"pol_predicted_arrival_lt,omitempty"`
 	// Portcast Predicted Time of Departure from the starting port location - Local Time
-	PolPredictedDepartureLt NullableTime `json:"pol_predicted_departure_lt,omitempty"`
+	PolPredictedDepartureLt NullableString `json:"pol_predicted_departure_lt,omitempty"`
 	// Scheduled Time of Arrival at the starting port location as per Vessel Schedule- Local Time
-	PolScheduledArrivalLtFromSchedule NullableTime `json:"pol_scheduled_arrival_lt_from_schedule,omitempty"`
+	PolScheduledArrivalLtFromSchedule NullableString `json:"pol_scheduled_arrival_lt_from_schedule,omitempty"`
 	// Scheduled Time of Departure from the starting port location - Local Time
-	PolScheduledDepartureLt NullableTime `json:"pol_scheduled_departure_lt,omitempty"`
+	PolScheduledDepartureLt NullableString `json:"pol_scheduled_departure_lt,omitempty"`
 	// Scheduled Time of Departure from the starting port location as per Vessel Schedule - Local Time
-	PolScheduledDepartureLtFromSchedule NullableTime `json:"pol_scheduled_departure_lt_from_schedule,omitempty"`
+	PolScheduledDepartureLtFromSchedule NullableString `json:"pol_scheduled_departure_lt_from_schedule,omitempty"`
 	// Scheduled Loading Time at the starting port location - Local Time
-	PolScheduledLoadingLt NullableTime `json:"pol_scheduled_loading_lt,omitempty"`
+	PolScheduledLoadingLt NullableString `json:"pol_scheduled_loading_lt,omitempty"`
 	// Terminal Name for the Port of Loading (POL)
 	PolTerminalName NullableString `json:"pol_terminal_name,omitempty"`
 	// Sailing Info Updated Date
@@ -347,9 +347,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPod() {
 }
 
 // GetPodActualArrivalLt returns the PodActualArrivalLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPodActualArrivalLt() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPodActualArrivalLt() string {
 	if o == nil || IsNil(o.PodActualArrivalLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodActualArrivalLt.Get()
@@ -358,7 +358,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPodActualArrivalLt() time.Time {
 // GetPodActualArrivalLtOk returns a tuple with the PodActualArrivalLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPodActualArrivalLtOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPodActualArrivalLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -374,8 +374,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPodActualArrivalLt() bool {
 	return false
 }
 
-// SetPodActualArrivalLt gets a reference to the given NullableTime and assigns it to the PodActualArrivalLt field.
-func (o *SailingInfoTrackingSailingInfo) SetPodActualArrivalLt(v time.Time) {
+// SetPodActualArrivalLt gets a reference to the given NullableString and assigns it to the PodActualArrivalLt field.
+func (o *SailingInfoTrackingSailingInfo) SetPodActualArrivalLt(v string) {
 	o.PodActualArrivalLt.Set(&v)
 }
 // SetPodActualArrivalLtNil sets the value for PodActualArrivalLt to be an explicit nil
@@ -389,9 +389,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPodActualArrivalLt() {
 }
 
 // GetPodActualArrivalLtFromAis returns the PodActualArrivalLtFromAis field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPodActualArrivalLtFromAis() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPodActualArrivalLtFromAis() string {
 	if o == nil || IsNil(o.PodActualArrivalLtFromAis.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodActualArrivalLtFromAis.Get()
@@ -400,7 +400,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPodActualArrivalLtFromAis() time.Tim
 // GetPodActualArrivalLtFromAisOk returns a tuple with the PodActualArrivalLtFromAis field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPodActualArrivalLtFromAisOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPodActualArrivalLtFromAisOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -416,8 +416,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPodActualArrivalLtFromAis() bool {
 	return false
 }
 
-// SetPodActualArrivalLtFromAis gets a reference to the given NullableTime and assigns it to the PodActualArrivalLtFromAis field.
-func (o *SailingInfoTrackingSailingInfo) SetPodActualArrivalLtFromAis(v time.Time) {
+// SetPodActualArrivalLtFromAis gets a reference to the given NullableString and assigns it to the PodActualArrivalLtFromAis field.
+func (o *SailingInfoTrackingSailingInfo) SetPodActualArrivalLtFromAis(v string) {
 	o.PodActualArrivalLtFromAis.Set(&v)
 }
 // SetPodActualArrivalLtFromAisNil sets the value for PodActualArrivalLtFromAis to be an explicit nil
@@ -431,9 +431,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPodActualArrivalLtFromAis() {
 }
 
 // GetPodActualDepartureLtFromAis returns the PodActualDepartureLtFromAis field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPodActualDepartureLtFromAis() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPodActualDepartureLtFromAis() string {
 	if o == nil || IsNil(o.PodActualDepartureLtFromAis.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodActualDepartureLtFromAis.Get()
@@ -442,7 +442,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPodActualDepartureLtFromAis() time.T
 // GetPodActualDepartureLtFromAisOk returns a tuple with the PodActualDepartureLtFromAis field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPodActualDepartureLtFromAisOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPodActualDepartureLtFromAisOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -458,8 +458,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPodActualDepartureLtFromAis() bool {
 	return false
 }
 
-// SetPodActualDepartureLtFromAis gets a reference to the given NullableTime and assigns it to the PodActualDepartureLtFromAis field.
-func (o *SailingInfoTrackingSailingInfo) SetPodActualDepartureLtFromAis(v time.Time) {
+// SetPodActualDepartureLtFromAis gets a reference to the given NullableString and assigns it to the PodActualDepartureLtFromAis field.
+func (o *SailingInfoTrackingSailingInfo) SetPodActualDepartureLtFromAis(v string) {
 	o.PodActualDepartureLtFromAis.Set(&v)
 }
 // SetPodActualDepartureLtFromAisNil sets the value for PodActualDepartureLtFromAis to be an explicit nil
@@ -473,9 +473,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPodActualDepartureLtFromAis() {
 }
 
 // GetPodActualDischargeLt returns the PodActualDischargeLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPodActualDischargeLt() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPodActualDischargeLt() string {
 	if o == nil || IsNil(o.PodActualDischargeLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodActualDischargeLt.Get()
@@ -484,7 +484,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPodActualDischargeLt() time.Time {
 // GetPodActualDischargeLtOk returns a tuple with the PodActualDischargeLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPodActualDischargeLtOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPodActualDischargeLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -500,8 +500,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPodActualDischargeLt() bool {
 	return false
 }
 
-// SetPodActualDischargeLt gets a reference to the given NullableTime and assigns it to the PodActualDischargeLt field.
-func (o *SailingInfoTrackingSailingInfo) SetPodActualDischargeLt(v time.Time) {
+// SetPodActualDischargeLt gets a reference to the given NullableString and assigns it to the PodActualDischargeLt field.
+func (o *SailingInfoTrackingSailingInfo) SetPodActualDischargeLt(v string) {
 	o.PodActualDischargeLt.Set(&v)
 }
 // SetPodActualDischargeLtNil sets the value for PodActualDischargeLt to be an explicit nil
@@ -557,9 +557,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPodName() {
 }
 
 // GetPodPredictedArrivalLt returns the PodPredictedArrivalLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPodPredictedArrivalLt() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPodPredictedArrivalLt() string {
 	if o == nil || IsNil(o.PodPredictedArrivalLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodPredictedArrivalLt.Get()
@@ -568,7 +568,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPodPredictedArrivalLt() time.Time {
 // GetPodPredictedArrivalLtOk returns a tuple with the PodPredictedArrivalLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPodPredictedArrivalLtOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPodPredictedArrivalLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -584,8 +584,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPodPredictedArrivalLt() bool {
 	return false
 }
 
-// SetPodPredictedArrivalLt gets a reference to the given NullableTime and assigns it to the PodPredictedArrivalLt field.
-func (o *SailingInfoTrackingSailingInfo) SetPodPredictedArrivalLt(v time.Time) {
+// SetPodPredictedArrivalLt gets a reference to the given NullableString and assigns it to the PodPredictedArrivalLt field.
+func (o *SailingInfoTrackingSailingInfo) SetPodPredictedArrivalLt(v string) {
 	o.PodPredictedArrivalLt.Set(&v)
 }
 // SetPodPredictedArrivalLtNil sets the value for PodPredictedArrivalLt to be an explicit nil
@@ -599,9 +599,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPodPredictedArrivalLt() {
 }
 
 // GetPodPredictedDepartureLt returns the PodPredictedDepartureLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPodPredictedDepartureLt() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPodPredictedDepartureLt() string {
 	if o == nil || IsNil(o.PodPredictedDepartureLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodPredictedDepartureLt.Get()
@@ -610,7 +610,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPodPredictedDepartureLt() time.Time 
 // GetPodPredictedDepartureLtOk returns a tuple with the PodPredictedDepartureLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPodPredictedDepartureLtOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPodPredictedDepartureLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -626,8 +626,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPodPredictedDepartureLt() bool {
 	return false
 }
 
-// SetPodPredictedDepartureLt gets a reference to the given NullableTime and assigns it to the PodPredictedDepartureLt field.
-func (o *SailingInfoTrackingSailingInfo) SetPodPredictedDepartureLt(v time.Time) {
+// SetPodPredictedDepartureLt gets a reference to the given NullableString and assigns it to the PodPredictedDepartureLt field.
+func (o *SailingInfoTrackingSailingInfo) SetPodPredictedDepartureLt(v string) {
 	o.PodPredictedDepartureLt.Set(&v)
 }
 // SetPodPredictedDepartureLtNil sets the value for PodPredictedDepartureLt to be an explicit nil
@@ -641,9 +641,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPodPredictedDepartureLt() {
 }
 
 // GetPodScheduledArrivalLt returns the PodScheduledArrivalLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPodScheduledArrivalLt() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPodScheduledArrivalLt() string {
 	if o == nil || IsNil(o.PodScheduledArrivalLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodScheduledArrivalLt.Get()
@@ -652,7 +652,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPodScheduledArrivalLt() time.Time {
 // GetPodScheduledArrivalLtOk returns a tuple with the PodScheduledArrivalLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPodScheduledArrivalLtOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPodScheduledArrivalLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -668,8 +668,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPodScheduledArrivalLt() bool {
 	return false
 }
 
-// SetPodScheduledArrivalLt gets a reference to the given NullableTime and assigns it to the PodScheduledArrivalLt field.
-func (o *SailingInfoTrackingSailingInfo) SetPodScheduledArrivalLt(v time.Time) {
+// SetPodScheduledArrivalLt gets a reference to the given NullableString and assigns it to the PodScheduledArrivalLt field.
+func (o *SailingInfoTrackingSailingInfo) SetPodScheduledArrivalLt(v string) {
 	o.PodScheduledArrivalLt.Set(&v)
 }
 // SetPodScheduledArrivalLtNil sets the value for PodScheduledArrivalLt to be an explicit nil
@@ -683,9 +683,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPodScheduledArrivalLt() {
 }
 
 // GetPodScheduledArrivalLtFromSchedule returns the PodScheduledArrivalLtFromSchedule field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPodScheduledArrivalLtFromSchedule() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPodScheduledArrivalLtFromSchedule() string {
 	if o == nil || IsNil(o.PodScheduledArrivalLtFromSchedule.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodScheduledArrivalLtFromSchedule.Get()
@@ -694,7 +694,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPodScheduledArrivalLtFromSchedule() 
 // GetPodScheduledArrivalLtFromScheduleOk returns a tuple with the PodScheduledArrivalLtFromSchedule field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPodScheduledArrivalLtFromScheduleOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPodScheduledArrivalLtFromScheduleOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -710,8 +710,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPodScheduledArrivalLtFromSchedule() 
 	return false
 }
 
-// SetPodScheduledArrivalLtFromSchedule gets a reference to the given NullableTime and assigns it to the PodScheduledArrivalLtFromSchedule field.
-func (o *SailingInfoTrackingSailingInfo) SetPodScheduledArrivalLtFromSchedule(v time.Time) {
+// SetPodScheduledArrivalLtFromSchedule gets a reference to the given NullableString and assigns it to the PodScheduledArrivalLtFromSchedule field.
+func (o *SailingInfoTrackingSailingInfo) SetPodScheduledArrivalLtFromSchedule(v string) {
 	o.PodScheduledArrivalLtFromSchedule.Set(&v)
 }
 // SetPodScheduledArrivalLtFromScheduleNil sets the value for PodScheduledArrivalLtFromSchedule to be an explicit nil
@@ -725,9 +725,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPodScheduledArrivalLtFromSchedule(
 }
 
 // GetPodScheduledDepartureLtFromSchedule returns the PodScheduledDepartureLtFromSchedule field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPodScheduledDepartureLtFromSchedule() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPodScheduledDepartureLtFromSchedule() string {
 	if o == nil || IsNil(o.PodScheduledDepartureLtFromSchedule.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodScheduledDepartureLtFromSchedule.Get()
@@ -736,7 +736,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPodScheduledDepartureLtFromSchedule(
 // GetPodScheduledDepartureLtFromScheduleOk returns a tuple with the PodScheduledDepartureLtFromSchedule field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPodScheduledDepartureLtFromScheduleOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPodScheduledDepartureLtFromScheduleOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -752,8 +752,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPodScheduledDepartureLtFromSchedule(
 	return false
 }
 
-// SetPodScheduledDepartureLtFromSchedule gets a reference to the given NullableTime and assigns it to the PodScheduledDepartureLtFromSchedule field.
-func (o *SailingInfoTrackingSailingInfo) SetPodScheduledDepartureLtFromSchedule(v time.Time) {
+// SetPodScheduledDepartureLtFromSchedule gets a reference to the given NullableString and assigns it to the PodScheduledDepartureLtFromSchedule field.
+func (o *SailingInfoTrackingSailingInfo) SetPodScheduledDepartureLtFromSchedule(v string) {
 	o.PodScheduledDepartureLtFromSchedule.Set(&v)
 }
 // SetPodScheduledDepartureLtFromScheduleNil sets the value for PodScheduledDepartureLtFromSchedule to be an explicit nil
@@ -767,9 +767,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPodScheduledDepartureLtFromSchedul
 }
 
 // GetPodScheduledDischargeLt returns the PodScheduledDischargeLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPodScheduledDischargeLt() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPodScheduledDischargeLt() string {
 	if o == nil || IsNil(o.PodScheduledDischargeLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PodScheduledDischargeLt.Get()
@@ -778,7 +778,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPodScheduledDischargeLt() time.Time 
 // GetPodScheduledDischargeLtOk returns a tuple with the PodScheduledDischargeLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPodScheduledDischargeLtOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPodScheduledDischargeLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -794,8 +794,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPodScheduledDischargeLt() bool {
 	return false
 }
 
-// SetPodScheduledDischargeLt gets a reference to the given NullableTime and assigns it to the PodScheduledDischargeLt field.
-func (o *SailingInfoTrackingSailingInfo) SetPodScheduledDischargeLt(v time.Time) {
+// SetPodScheduledDischargeLt gets a reference to the given NullableString and assigns it to the PodScheduledDischargeLt field.
+func (o *SailingInfoTrackingSailingInfo) SetPodScheduledDischargeLt(v string) {
 	o.PodScheduledDischargeLt.Set(&v)
 }
 // SetPodScheduledDischargeLtNil sets the value for PodScheduledDischargeLt to be an explicit nil
@@ -893,9 +893,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPol() {
 }
 
 // GetPolActualArrivalLtFromAis returns the PolActualArrivalLtFromAis field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPolActualArrivalLtFromAis() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPolActualArrivalLtFromAis() string {
 	if o == nil || IsNil(o.PolActualArrivalLtFromAis.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolActualArrivalLtFromAis.Get()
@@ -904,7 +904,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPolActualArrivalLtFromAis() time.Tim
 // GetPolActualArrivalLtFromAisOk returns a tuple with the PolActualArrivalLtFromAis field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPolActualArrivalLtFromAisOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPolActualArrivalLtFromAisOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -920,8 +920,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPolActualArrivalLtFromAis() bool {
 	return false
 }
 
-// SetPolActualArrivalLtFromAis gets a reference to the given NullableTime and assigns it to the PolActualArrivalLtFromAis field.
-func (o *SailingInfoTrackingSailingInfo) SetPolActualArrivalLtFromAis(v time.Time) {
+// SetPolActualArrivalLtFromAis gets a reference to the given NullableString and assigns it to the PolActualArrivalLtFromAis field.
+func (o *SailingInfoTrackingSailingInfo) SetPolActualArrivalLtFromAis(v string) {
 	o.PolActualArrivalLtFromAis.Set(&v)
 }
 // SetPolActualArrivalLtFromAisNil sets the value for PolActualArrivalLtFromAis to be an explicit nil
@@ -935,9 +935,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPolActualArrivalLtFromAis() {
 }
 
 // GetPolActualDepartureLt returns the PolActualDepartureLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPolActualDepartureLt() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPolActualDepartureLt() string {
 	if o == nil || IsNil(o.PolActualDepartureLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolActualDepartureLt.Get()
@@ -946,7 +946,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPolActualDepartureLt() time.Time {
 // GetPolActualDepartureLtOk returns a tuple with the PolActualDepartureLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPolActualDepartureLtOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPolActualDepartureLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -962,8 +962,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPolActualDepartureLt() bool {
 	return false
 }
 
-// SetPolActualDepartureLt gets a reference to the given NullableTime and assigns it to the PolActualDepartureLt field.
-func (o *SailingInfoTrackingSailingInfo) SetPolActualDepartureLt(v time.Time) {
+// SetPolActualDepartureLt gets a reference to the given NullableString and assigns it to the PolActualDepartureLt field.
+func (o *SailingInfoTrackingSailingInfo) SetPolActualDepartureLt(v string) {
 	o.PolActualDepartureLt.Set(&v)
 }
 // SetPolActualDepartureLtNil sets the value for PolActualDepartureLt to be an explicit nil
@@ -977,9 +977,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPolActualDepartureLt() {
 }
 
 // GetPolActualDepartureLtFromAis returns the PolActualDepartureLtFromAis field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPolActualDepartureLtFromAis() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPolActualDepartureLtFromAis() string {
 	if o == nil || IsNil(o.PolActualDepartureLtFromAis.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolActualDepartureLtFromAis.Get()
@@ -988,7 +988,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPolActualDepartureLtFromAis() time.T
 // GetPolActualDepartureLtFromAisOk returns a tuple with the PolActualDepartureLtFromAis field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPolActualDepartureLtFromAisOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPolActualDepartureLtFromAisOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -1004,8 +1004,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPolActualDepartureLtFromAis() bool {
 	return false
 }
 
-// SetPolActualDepartureLtFromAis gets a reference to the given NullableTime and assigns it to the PolActualDepartureLtFromAis field.
-func (o *SailingInfoTrackingSailingInfo) SetPolActualDepartureLtFromAis(v time.Time) {
+// SetPolActualDepartureLtFromAis gets a reference to the given NullableString and assigns it to the PolActualDepartureLtFromAis field.
+func (o *SailingInfoTrackingSailingInfo) SetPolActualDepartureLtFromAis(v string) {
 	o.PolActualDepartureLtFromAis.Set(&v)
 }
 // SetPolActualDepartureLtFromAisNil sets the value for PolActualDepartureLtFromAis to be an explicit nil
@@ -1019,9 +1019,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPolActualDepartureLtFromAis() {
 }
 
 // GetPolActualLoadingLt returns the PolActualLoadingLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPolActualLoadingLt() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPolActualLoadingLt() string {
 	if o == nil || IsNil(o.PolActualLoadingLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolActualLoadingLt.Get()
@@ -1030,7 +1030,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPolActualLoadingLt() time.Time {
 // GetPolActualLoadingLtOk returns a tuple with the PolActualLoadingLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPolActualLoadingLtOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPolActualLoadingLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -1046,8 +1046,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPolActualLoadingLt() bool {
 	return false
 }
 
-// SetPolActualLoadingLt gets a reference to the given NullableTime and assigns it to the PolActualLoadingLt field.
-func (o *SailingInfoTrackingSailingInfo) SetPolActualLoadingLt(v time.Time) {
+// SetPolActualLoadingLt gets a reference to the given NullableString and assigns it to the PolActualLoadingLt field.
+func (o *SailingInfoTrackingSailingInfo) SetPolActualLoadingLt(v string) {
 	o.PolActualLoadingLt.Set(&v)
 }
 // SetPolActualLoadingLtNil sets the value for PolActualLoadingLt to be an explicit nil
@@ -1103,9 +1103,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPolName() {
 }
 
 // GetPolPredictedArrivalLt returns the PolPredictedArrivalLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPolPredictedArrivalLt() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPolPredictedArrivalLt() string {
 	if o == nil || IsNil(o.PolPredictedArrivalLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolPredictedArrivalLt.Get()
@@ -1114,7 +1114,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPolPredictedArrivalLt() time.Time {
 // GetPolPredictedArrivalLtOk returns a tuple with the PolPredictedArrivalLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPolPredictedArrivalLtOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPolPredictedArrivalLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -1130,8 +1130,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPolPredictedArrivalLt() bool {
 	return false
 }
 
-// SetPolPredictedArrivalLt gets a reference to the given NullableTime and assigns it to the PolPredictedArrivalLt field.
-func (o *SailingInfoTrackingSailingInfo) SetPolPredictedArrivalLt(v time.Time) {
+// SetPolPredictedArrivalLt gets a reference to the given NullableString and assigns it to the PolPredictedArrivalLt field.
+func (o *SailingInfoTrackingSailingInfo) SetPolPredictedArrivalLt(v string) {
 	o.PolPredictedArrivalLt.Set(&v)
 }
 // SetPolPredictedArrivalLtNil sets the value for PolPredictedArrivalLt to be an explicit nil
@@ -1145,9 +1145,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPolPredictedArrivalLt() {
 }
 
 // GetPolPredictedDepartureLt returns the PolPredictedDepartureLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPolPredictedDepartureLt() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPolPredictedDepartureLt() string {
 	if o == nil || IsNil(o.PolPredictedDepartureLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolPredictedDepartureLt.Get()
@@ -1156,7 +1156,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPolPredictedDepartureLt() time.Time 
 // GetPolPredictedDepartureLtOk returns a tuple with the PolPredictedDepartureLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPolPredictedDepartureLtOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPolPredictedDepartureLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -1172,8 +1172,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPolPredictedDepartureLt() bool {
 	return false
 }
 
-// SetPolPredictedDepartureLt gets a reference to the given NullableTime and assigns it to the PolPredictedDepartureLt field.
-func (o *SailingInfoTrackingSailingInfo) SetPolPredictedDepartureLt(v time.Time) {
+// SetPolPredictedDepartureLt gets a reference to the given NullableString and assigns it to the PolPredictedDepartureLt field.
+func (o *SailingInfoTrackingSailingInfo) SetPolPredictedDepartureLt(v string) {
 	o.PolPredictedDepartureLt.Set(&v)
 }
 // SetPolPredictedDepartureLtNil sets the value for PolPredictedDepartureLt to be an explicit nil
@@ -1187,9 +1187,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPolPredictedDepartureLt() {
 }
 
 // GetPolScheduledArrivalLtFromSchedule returns the PolScheduledArrivalLtFromSchedule field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPolScheduledArrivalLtFromSchedule() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPolScheduledArrivalLtFromSchedule() string {
 	if o == nil || IsNil(o.PolScheduledArrivalLtFromSchedule.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolScheduledArrivalLtFromSchedule.Get()
@@ -1198,7 +1198,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPolScheduledArrivalLtFromSchedule() 
 // GetPolScheduledArrivalLtFromScheduleOk returns a tuple with the PolScheduledArrivalLtFromSchedule field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPolScheduledArrivalLtFromScheduleOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPolScheduledArrivalLtFromScheduleOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -1214,8 +1214,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPolScheduledArrivalLtFromSchedule() 
 	return false
 }
 
-// SetPolScheduledArrivalLtFromSchedule gets a reference to the given NullableTime and assigns it to the PolScheduledArrivalLtFromSchedule field.
-func (o *SailingInfoTrackingSailingInfo) SetPolScheduledArrivalLtFromSchedule(v time.Time) {
+// SetPolScheduledArrivalLtFromSchedule gets a reference to the given NullableString and assigns it to the PolScheduledArrivalLtFromSchedule field.
+func (o *SailingInfoTrackingSailingInfo) SetPolScheduledArrivalLtFromSchedule(v string) {
 	o.PolScheduledArrivalLtFromSchedule.Set(&v)
 }
 // SetPolScheduledArrivalLtFromScheduleNil sets the value for PolScheduledArrivalLtFromSchedule to be an explicit nil
@@ -1229,9 +1229,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPolScheduledArrivalLtFromSchedule(
 }
 
 // GetPolScheduledDepartureLt returns the PolScheduledDepartureLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPolScheduledDepartureLt() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPolScheduledDepartureLt() string {
 	if o == nil || IsNil(o.PolScheduledDepartureLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolScheduledDepartureLt.Get()
@@ -1240,7 +1240,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPolScheduledDepartureLt() time.Time 
 // GetPolScheduledDepartureLtOk returns a tuple with the PolScheduledDepartureLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPolScheduledDepartureLtOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPolScheduledDepartureLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -1256,8 +1256,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPolScheduledDepartureLt() bool {
 	return false
 }
 
-// SetPolScheduledDepartureLt gets a reference to the given NullableTime and assigns it to the PolScheduledDepartureLt field.
-func (o *SailingInfoTrackingSailingInfo) SetPolScheduledDepartureLt(v time.Time) {
+// SetPolScheduledDepartureLt gets a reference to the given NullableString and assigns it to the PolScheduledDepartureLt field.
+func (o *SailingInfoTrackingSailingInfo) SetPolScheduledDepartureLt(v string) {
 	o.PolScheduledDepartureLt.Set(&v)
 }
 // SetPolScheduledDepartureLtNil sets the value for PolScheduledDepartureLt to be an explicit nil
@@ -1271,9 +1271,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPolScheduledDepartureLt() {
 }
 
 // GetPolScheduledDepartureLtFromSchedule returns the PolScheduledDepartureLtFromSchedule field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPolScheduledDepartureLtFromSchedule() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPolScheduledDepartureLtFromSchedule() string {
 	if o == nil || IsNil(o.PolScheduledDepartureLtFromSchedule.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolScheduledDepartureLtFromSchedule.Get()
@@ -1282,7 +1282,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPolScheduledDepartureLtFromSchedule(
 // GetPolScheduledDepartureLtFromScheduleOk returns a tuple with the PolScheduledDepartureLtFromSchedule field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPolScheduledDepartureLtFromScheduleOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPolScheduledDepartureLtFromScheduleOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -1298,8 +1298,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPolScheduledDepartureLtFromSchedule(
 	return false
 }
 
-// SetPolScheduledDepartureLtFromSchedule gets a reference to the given NullableTime and assigns it to the PolScheduledDepartureLtFromSchedule field.
-func (o *SailingInfoTrackingSailingInfo) SetPolScheduledDepartureLtFromSchedule(v time.Time) {
+// SetPolScheduledDepartureLtFromSchedule gets a reference to the given NullableString and assigns it to the PolScheduledDepartureLtFromSchedule field.
+func (o *SailingInfoTrackingSailingInfo) SetPolScheduledDepartureLtFromSchedule(v string) {
 	o.PolScheduledDepartureLtFromSchedule.Set(&v)
 }
 // SetPolScheduledDepartureLtFromScheduleNil sets the value for PolScheduledDepartureLtFromSchedule to be an explicit nil
@@ -1313,9 +1313,9 @@ func (o *SailingInfoTrackingSailingInfo) UnsetPolScheduledDepartureLtFromSchedul
 }
 
 // GetPolScheduledLoadingLt returns the PolScheduledLoadingLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *SailingInfoTrackingSailingInfo) GetPolScheduledLoadingLt() time.Time {
+func (o *SailingInfoTrackingSailingInfo) GetPolScheduledLoadingLt() string {
 	if o == nil || IsNil(o.PolScheduledLoadingLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PolScheduledLoadingLt.Get()
@@ -1324,7 +1324,7 @@ func (o *SailingInfoTrackingSailingInfo) GetPolScheduledLoadingLt() time.Time {
 // GetPolScheduledLoadingLtOk returns a tuple with the PolScheduledLoadingLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *SailingInfoTrackingSailingInfo) GetPolScheduledLoadingLtOk() (*time.Time, bool) {
+func (o *SailingInfoTrackingSailingInfo) GetPolScheduledLoadingLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -1340,8 +1340,8 @@ func (o *SailingInfoTrackingSailingInfo) HasPolScheduledLoadingLt() bool {
 	return false
 }
 
-// SetPolScheduledLoadingLt gets a reference to the given NullableTime and assigns it to the PolScheduledLoadingLt field.
-func (o *SailingInfoTrackingSailingInfo) SetPolScheduledLoadingLt(v time.Time) {
+// SetPolScheduledLoadingLt gets a reference to the given NullableString and assigns it to the PolScheduledLoadingLt field.
+func (o *SailingInfoTrackingSailingInfo) SetPolScheduledLoadingLt(v string) {
 	o.PolScheduledLoadingLt.Set(&v)
 }
 // SetPolScheduledLoadingLtNil sets the value for PolScheduledLoadingLt to be an explicit nil

--- a/portcast/model_voyage_details.go
+++ b/portcast/model_voyage_details.go
@@ -24,11 +24,11 @@ type VoyageDetails struct {
 	// Vessel Schedule Provider SCAC
 	ActiveScac NullableString `json:"active_scac,omitempty"`
 	// Actual Time of Arrival - Local Time
-	ActualArrivalLt NullableTime `json:"actual_arrival_lt,omitempty"`
+	ActualArrivalLt NullableString `json:"actual_arrival_lt,omitempty"`
 	// Actual Time of Arrival - UTC Adjusted Time
 	ActualArrivalUtc NullableTime `json:"actual_arrival_utc,omitempty"`
 	// Actual Time of Departure - Local Time
-	ActualDepartureLt NullableTime `json:"actual_departure_lt,omitempty"`
+	ActualDepartureLt NullableString `json:"actual_departure_lt,omitempty"`
 	// Actual Time of Departure - UTC Adjusted Time
 	ActualDepartureUtc NullableTime `json:"actual_departure_utc,omitempty"`
 	DelayReasons []string `json:"delay_reasons,omitempty"`
@@ -45,21 +45,21 @@ type VoyageDetails struct {
 	// Port Location Name
 	PortName *string `json:"port_name,omitempty"`
 	// Portcast Predicted Arrival Time - Local Time
-	PredictedArrivalLt NullableTime `json:"predicted_arrival_lt,omitempty"`
+	PredictedArrivalLt NullableString `json:"predicted_arrival_lt,omitempty"`
 	// Portcast Predicted Arrival Time - UTC Adjusted
 	PredictedArrivalUtc NullableTime `json:"predicted_arrival_utc,omitempty"`
 	// Portcast Predicted Departure Time - Local Time
-	PredictedDepartureLt NullableTime `json:"predicted_departure_lt,omitempty"`
+	PredictedDepartureLt NullableString `json:"predicted_departure_lt,omitempty"`
 	// Portcast Predicted Departure Time - UTC Adjusted Time
 	PredictedDepartureUtc NullableTime `json:"predicted_departure_utc,omitempty"`
 	// Prediction Generation Timestamp
 	PredictionTimeUtc NullableTime `json:"prediction_time_utc,omitempty"`
 	// Vessel Scheduled Arrival Time - Local Time
-	ScheduledArrivalLt NullableTime `json:"scheduled_arrival_lt,omitempty"`
+	ScheduledArrivalLt NullableString `json:"scheduled_arrival_lt,omitempty"`
 	// Vessel Scheduled Arrival Time - UTC Adjusted Time
 	ScheduledArrivalUtc NullableTime `json:"scheduled_arrival_utc,omitempty"`
 	// Vessel Scheduled Departure Time - Local Time
-	ScheduledDepartureLt NullableTime `json:"scheduled_departure_lt,omitempty"`
+	ScheduledDepartureLt NullableString `json:"scheduled_departure_lt,omitempty"`
 	// Vessel Scheduled Departure Time - Departure Time
 	ScheduledDepartureUtc NullableTime `json:"scheduled_departure_utc,omitempty"`
 	// Timezone of the Port Location
@@ -128,9 +128,9 @@ func (o *VoyageDetails) UnsetActiveScac() {
 }
 
 // GetActualArrivalLt returns the ActualArrivalLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *VoyageDetails) GetActualArrivalLt() time.Time {
+func (o *VoyageDetails) GetActualArrivalLt() string {
 	if o == nil || IsNil(o.ActualArrivalLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.ActualArrivalLt.Get()
@@ -139,7 +139,7 @@ func (o *VoyageDetails) GetActualArrivalLt() time.Time {
 // GetActualArrivalLtOk returns a tuple with the ActualArrivalLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *VoyageDetails) GetActualArrivalLtOk() (*time.Time, bool) {
+func (o *VoyageDetails) GetActualArrivalLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -155,8 +155,8 @@ func (o *VoyageDetails) HasActualArrivalLt() bool {
 	return false
 }
 
-// SetActualArrivalLt gets a reference to the given NullableTime and assigns it to the ActualArrivalLt field.
-func (o *VoyageDetails) SetActualArrivalLt(v time.Time) {
+// SetActualArrivalLt gets a reference to the given NullableString and assigns it to the ActualArrivalLt field.
+func (o *VoyageDetails) SetActualArrivalLt(v string) {
 	o.ActualArrivalLt.Set(&v)
 }
 // SetActualArrivalLtNil sets the value for ActualArrivalLt to be an explicit nil
@@ -212,9 +212,9 @@ func (o *VoyageDetails) UnsetActualArrivalUtc() {
 }
 
 // GetActualDepartureLt returns the ActualDepartureLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *VoyageDetails) GetActualDepartureLt() time.Time {
+func (o *VoyageDetails) GetActualDepartureLt() string {
 	if o == nil || IsNil(o.ActualDepartureLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.ActualDepartureLt.Get()
@@ -223,7 +223,7 @@ func (o *VoyageDetails) GetActualDepartureLt() time.Time {
 // GetActualDepartureLtOk returns a tuple with the ActualDepartureLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *VoyageDetails) GetActualDepartureLtOk() (*time.Time, bool) {
+func (o *VoyageDetails) GetActualDepartureLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -239,8 +239,8 @@ func (o *VoyageDetails) HasActualDepartureLt() bool {
 	return false
 }
 
-// SetActualDepartureLt gets a reference to the given NullableTime and assigns it to the ActualDepartureLt field.
-func (o *VoyageDetails) SetActualDepartureLt(v time.Time) {
+// SetActualDepartureLt gets a reference to the given NullableString and assigns it to the ActualDepartureLt field.
+func (o *VoyageDetails) SetActualDepartureLt(v string) {
 	o.ActualDepartureLt.Set(&v)
 }
 // SetActualDepartureLtNil sets the value for ActualDepartureLt to be an explicit nil
@@ -520,9 +520,9 @@ func (o *VoyageDetails) SetPortName(v string) {
 }
 
 // GetPredictedArrivalLt returns the PredictedArrivalLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *VoyageDetails) GetPredictedArrivalLt() time.Time {
+func (o *VoyageDetails) GetPredictedArrivalLt() string {
 	if o == nil || IsNil(o.PredictedArrivalLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PredictedArrivalLt.Get()
@@ -531,7 +531,7 @@ func (o *VoyageDetails) GetPredictedArrivalLt() time.Time {
 // GetPredictedArrivalLtOk returns a tuple with the PredictedArrivalLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *VoyageDetails) GetPredictedArrivalLtOk() (*time.Time, bool) {
+func (o *VoyageDetails) GetPredictedArrivalLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -547,8 +547,8 @@ func (o *VoyageDetails) HasPredictedArrivalLt() bool {
 	return false
 }
 
-// SetPredictedArrivalLt gets a reference to the given NullableTime and assigns it to the PredictedArrivalLt field.
-func (o *VoyageDetails) SetPredictedArrivalLt(v time.Time) {
+// SetPredictedArrivalLt gets a reference to the given NullableString and assigns it to the PredictedArrivalLt field.
+func (o *VoyageDetails) SetPredictedArrivalLt(v string) {
 	o.PredictedArrivalLt.Set(&v)
 }
 // SetPredictedArrivalLtNil sets the value for PredictedArrivalLt to be an explicit nil
@@ -604,9 +604,9 @@ func (o *VoyageDetails) UnsetPredictedArrivalUtc() {
 }
 
 // GetPredictedDepartureLt returns the PredictedDepartureLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *VoyageDetails) GetPredictedDepartureLt() time.Time {
+func (o *VoyageDetails) GetPredictedDepartureLt() string {
 	if o == nil || IsNil(o.PredictedDepartureLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.PredictedDepartureLt.Get()
@@ -615,7 +615,7 @@ func (o *VoyageDetails) GetPredictedDepartureLt() time.Time {
 // GetPredictedDepartureLtOk returns a tuple with the PredictedDepartureLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *VoyageDetails) GetPredictedDepartureLtOk() (*time.Time, bool) {
+func (o *VoyageDetails) GetPredictedDepartureLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -631,8 +631,8 @@ func (o *VoyageDetails) HasPredictedDepartureLt() bool {
 	return false
 }
 
-// SetPredictedDepartureLt gets a reference to the given NullableTime and assigns it to the PredictedDepartureLt field.
-func (o *VoyageDetails) SetPredictedDepartureLt(v time.Time) {
+// SetPredictedDepartureLt gets a reference to the given NullableString and assigns it to the PredictedDepartureLt field.
+func (o *VoyageDetails) SetPredictedDepartureLt(v string) {
 	o.PredictedDepartureLt.Set(&v)
 }
 // SetPredictedDepartureLtNil sets the value for PredictedDepartureLt to be an explicit nil
@@ -730,9 +730,9 @@ func (o *VoyageDetails) UnsetPredictionTimeUtc() {
 }
 
 // GetScheduledArrivalLt returns the ScheduledArrivalLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *VoyageDetails) GetScheduledArrivalLt() time.Time {
+func (o *VoyageDetails) GetScheduledArrivalLt() string {
 	if o == nil || IsNil(o.ScheduledArrivalLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.ScheduledArrivalLt.Get()
@@ -741,7 +741,7 @@ func (o *VoyageDetails) GetScheduledArrivalLt() time.Time {
 // GetScheduledArrivalLtOk returns a tuple with the ScheduledArrivalLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *VoyageDetails) GetScheduledArrivalLtOk() (*time.Time, bool) {
+func (o *VoyageDetails) GetScheduledArrivalLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -757,8 +757,8 @@ func (o *VoyageDetails) HasScheduledArrivalLt() bool {
 	return false
 }
 
-// SetScheduledArrivalLt gets a reference to the given NullableTime and assigns it to the ScheduledArrivalLt field.
-func (o *VoyageDetails) SetScheduledArrivalLt(v time.Time) {
+// SetScheduledArrivalLt gets a reference to the given NullableString and assigns it to the ScheduledArrivalLt field.
+func (o *VoyageDetails) SetScheduledArrivalLt(v string) {
 	o.ScheduledArrivalLt.Set(&v)
 }
 // SetScheduledArrivalLtNil sets the value for ScheduledArrivalLt to be an explicit nil
@@ -814,9 +814,9 @@ func (o *VoyageDetails) UnsetScheduledArrivalUtc() {
 }
 
 // GetScheduledDepartureLt returns the ScheduledDepartureLt field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *VoyageDetails) GetScheduledDepartureLt() time.Time {
+func (o *VoyageDetails) GetScheduledDepartureLt() string {
 	if o == nil || IsNil(o.ScheduledDepartureLt.Get()) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.ScheduledDepartureLt.Get()
@@ -825,7 +825,7 @@ func (o *VoyageDetails) GetScheduledDepartureLt() time.Time {
 // GetScheduledDepartureLtOk returns a tuple with the ScheduledDepartureLt field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *VoyageDetails) GetScheduledDepartureLtOk() (*time.Time, bool) {
+func (o *VoyageDetails) GetScheduledDepartureLtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -841,8 +841,8 @@ func (o *VoyageDetails) HasScheduledDepartureLt() bool {
 	return false
 }
 
-// SetScheduledDepartureLt gets a reference to the given NullableTime and assigns it to the ScheduledDepartureLt field.
-func (o *VoyageDetails) SetScheduledDepartureLt(v time.Time) {
+// SetScheduledDepartureLt gets a reference to the given NullableString and assigns it to the ScheduledDepartureLt field.
+func (o *VoyageDetails) SetScheduledDepartureLt(v string) {
 	o.ScheduledDepartureLt.Set(&v)
 }
 // SetScheduledDepartureLtNil sets the value for ScheduledDepartureLt to be an explicit nil


### PR DESCRIPTION
Since Portcast can't ensure all those fields will have the timezone offest, we can't parse them as date-time in the sdk.